### PR TITLE
Add file io & configulator modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v0.1.3 - 2017-08
+   * additional improvements to code quality, but with some breaking changes
+   * changed argument handling for multiple utilities to simplify code and get more consistency.
+     - affects: gristle_freaker, gristle_slicer, and gristle_viewer
+     - This means words are separated by hyphens, not underscores.  --sortorder is --sort-order.
+   * changed file handling for multiple utilities to simplify code and get more consistency.
+     - affects: gristle_freaker, gristle_slicer, gristle_validator, and gristle_viewer
+     - This means that behavior in handling multiple files, piped input, and other edge cases
+       is more consistent between utilities.
+
+
 # v0.1.2 - 2017-06
    * long-overdue code quality updates
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,23 @@
+v0.1.3 - 2017-08
+================
+
+-  additional improvements to code quality, but with some breaking
+   changes
+-  changed argument handling for multiple utilities to simplify code and
+   get more consistency.
+
+   -  affects: gristle\_freaker, gristle\_slicer, and gristle\_viewer
+   -  This means words are separated by hyphens, not underscores.
+      --sortorder is --sort-order.
+
+-  changed file handling for multiple utilities to simplify code and get
+   more consistency.
+
+   -  affects: gristle\_freaker, gristle\_slicer, gristle\_validator,
+      and gristle\_viewer
+   -  This means that behavior in handling multiple files, piped input,
+      and other edge cases is more consistent between utilities.
+
 v0.1.2 - 2017-06
 ================
 

--- a/datagristle/file_io.py
+++ b/datagristle/file_io.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+""" Contains standard io reading & writing code
+
+    See the file "LICENSE" for the full license governing this code.
+    Copyright 2017 Ken Farmer
+"""
+import os
+import sys
+import csv
+import io
+import random
+import errno
+from os.path import isfile
+from pprint import pprint
+from typing import Union, Dict, List, Tuple, Any, Optional
+from pprint import pprint as pp
+
+import datagristle.csvhelper as csvhelper
+import datagristle.file_type as file_type
+
+
+
+class InputHandler(object):
+
+    def __init__(self,
+                 files: List[str],
+                 delimiter: Optional[str],
+                 quoting: Optional[str],
+                 quotechar: Optional[str],
+                 has_header: Optional[bool]) -> None:
+
+        self.files = files
+        self.files_read = 0
+        self.rec_cnt = 0
+        self.dialect = self._get_dialect(files,
+                                         delimiter,
+                                         quoting,
+                                         quotechar,
+                                         has_header)
+        if files[0] == '-':
+            if os.isatty(0):  # checks if data was pipped into stdin
+                #raise ValueError, "No files or stdin provided"
+                sys.exit(errno.ENODATA)
+            else:
+                input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8', newline='')
+                self.csv_reader = csv.reader(input_stream, dialect=self.dialect)
+                self.infile = sys.stdin
+                self.files_read = 1
+        else:
+            self.infile = open(files[0], 'rt', newline='', encoding='utf-8')
+            self.csv_reader = csv.reader(self.infile, dialect=self.dialect)
+            self.files_read = 1
+
+
+
+    def _get_dialect(self,
+                     infiles: List[str],
+                     delimiter: Optional[str],
+                     quoting: Optional[str],
+                     quotechar: Optional[str],
+                     has_header: Optional[bool]) -> csvhelper.Dialect:
+        if delimiter:
+            dialect = csvhelper.Dialect(delimiter=delimiter,
+                                        has_header=has_header,
+                                        quoting=file_type.get_quote_number(quoting),
+                                        quotechar=quotechar,
+                                        lineterminator='\n')
+        else:
+            for infile in infiles:
+                my_file = file_type.FileTyper(infile)
+                try:
+                    dialect = my_file.analyze_file()
+                    break
+                except file_type.IOErrorEmptyFile:
+                    continue
+            else:
+                raise EOFError
+        return dialect
+
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        """ Returns the next input record.   Can handle data piped in as well
+            as multiple input files.   All data is assumed to be csv files.
+        """
+        try:
+            rec = self.csv_reader.__next__()
+            self.rec_cnt += 1
+        except StopIteration:
+            if self.files_read < len(self.files): # another file to read!
+                self.files_read += 1
+                self.infile = open(self.files[self.files_read - 1], 'rt', newline='', encodings='utf-8')
+                self.csv_reader = csv.reader(self.infile, dialect=self.dialect)
+                rec = self.csv_reader.next()
+                self.rec_cnt += 1
+            else:
+                raise
+        else:
+            return rec
+
+
+    def close(self):
+        if self.files[0] != '-':
+            self.infile.close()
+
+
+
+
+class OutputHandler(object):
+    """ Handles all aspects of writing to output files: opening file,
+        writing records, managing random writes, keeping counts,
+        closing the file, etc.
+    """
+
+    def __init__(self,
+                 output_filename: str,
+                 dialect: csvhelper.Dialect,
+                 default_output = sys.stdout,
+                 dry_run: bool = False,
+                 random_out: float = 1.0):
+
+        assert default_output in (sys.stdout, sys.stderr), "invalid default_output: {}".format(default_output)
+        assert 0.0 <= random_out <= 1.0
+
+        self.output_filename = output_filename
+        self.dry_run = dry_run
+        self.random_out = random_out
+        if self.output_filename == '-':
+            self.outfile = default_output
+        else:
+            self.outfile = open(output_filename, "wt", encoding='utf-8')
+        if dialect:
+            self.writer = csv.writer(self.outfile, dialect=dialect)
+        else:
+            self.writer = None
+
+
+    def write_rec(self,
+                  record: List[str]) -> None:
+        """ Write a record to output.
+            If silent arg was provided, then write is suppressed.
+            If randomout arg was provided, then randomly determine
+               whether or not to write record.
+        """
+        if self.dry_run:
+            return
+        if self.random_out != 1.0:
+            if random.random() > self.random_out:
+                return
+        try:
+            self.writer.writerow(record)
+        except csv.Error:
+            print('Invalid record: %s' % record)
+            raise
+
+
+    def write_csv_rec(self,
+                      record: List[str]) -> None:
+        self.write_rec(record)
+
+
+    def write_text_rec(self,
+                       record: str) -> None:
+        self.outfile.write(record)
+
+
+
+    def close(self):
+        if self.output_filename != '-':
+            self.outfile.close()
+
+
+

--- a/datagristle/location_slicer.py
+++ b/datagristle/location_slicer.py
@@ -33,6 +33,7 @@
 """
 
 import sys
+from pprint import pprint as pp
 from typing import List, Dict, Tuple, Union, Any, Optional
 
 

--- a/datagristle/tests/test_location_slicer.py
+++ b/datagristle/tests/test_location_slicer.py
@@ -150,6 +150,13 @@ class TestSpecProcessorEvaluator(object):
         self.sp = mod.SpecProcessor(spec, spec_name)
         self.sp.spec_adjuster(loc_max)
 
+    def test_evaluate_starting_offsets(self):
+
+        self.simple_setup(['0'], 'rec_incl_spec', 80)
+        assert self.sp.adj_spec == self.sp.orig_spec
+        assert self.sp.spec_evaluator(0)
+        assert self.sp.spec_evaluator(1) is False
+
     def test_evaluate_positive_specs(self):
 
         self.simple_setup(['5'], 'rec_incl_spec', 80)

--- a/scripts/gristle_freaker
+++ b/scripts/gristle_freaker
@@ -4,37 +4,37 @@
     being the count of occurances.
 
     Examples:
-       $ gristle_freaker sample.csv -d '|'  -c 0
+       $ gristle_freaker -i sample.csv -d '|'  -c 0
                              Creates two columns from the input - the first with
                              unique keys from column 0, the second with a count
                              of how many times each exists.
-       $ gristle_freaker sample.csv -d '|'  -c 0 --sortcol 1 --sortorder forward
-         --writelimit 25
+       $ gristle_freaker -i sample.csv -d '|'  -c 0 --sort-col 1 --sort-order forward
+         --write-limit 25
                              In addition to what was described in the first
                              example, this example adds sorting of the output
                              by count ascending and just prints the first 25
                              entries.
-       $ gristle_freaker sample.csv -d '|'  -c 0 --sampling_rate 3
-         --sampling_method interval
+       $ gristle_freaker -i sample.csv -d '|'  -c 0 --sampling-rate 3
+         --sampling-method interval
                              In addition to what was described in the first
                              example, this example adds a sampling in which it
                              only references every third record.
-       $ gristle_freaker sample.csv -d '|'  -c 0,1
+       $ gristle_freaker -i sample.csv -d '|'  -c 0 1
                              Creates three columns from the input - the first
                              two with unique key combinations from columns 0
                              & 1, the third with the number of times each
                              combination exists.
-       $ gristle_freaker sample.csv -d '|'  -c -1
+       $ gristle_freaker -i sample.csv -d '|'  -c -1
                              Creates two columns from the input - the first
                              with unique keys from the last column of the file
                              (negative numbers wrap), then a second with the
                              number of times each exists.
-       $ gristle_freaker sample.csv -d '|'  --columntype all
+       $ gristle_freaker -i sample.csv -d '|'  --col-type all
                              Creates two columns from the input - all columns
                              combined into a key, then a second with the number
                              of times each combination exists.
-       $ gristle_freaker sample.csv -d '|'  --columntype each
-                             Unless all other examples, this one performs a
+       $ gristle_freaker -i sample.csv -d '|'  --col-type each
+                             Unlike all other examples, this one performs a
                              separate analysis for every single column of the
                              file.  Each analysis produces three columns from
                              the input - the first is a column number, second
@@ -42,153 +42,99 @@
                              is the number of times that value appeared.
                              This output is repeated for each column.
 
-    To do:
-    - add sampling method of random
-    - improve error msg if no input provided - tell user about -h
-
     This source code is protected by the BSD license.  See the file "LICENSE"
     in the source code root directory for the full language or refer to it here:
        http://opensource.org/licenses/BSD-3-Clause
     Copyright 2011,2012,2013,2017 Ken Farmer
 """
 import sys
-import io
-import optparse
-import csv
 import operator
-import os
+from os.path import basename
 import errno
-from typing import Dict, List, Tuple, Optional
+from pprint import pprint as pp
+from typing import Dict, List, Tuple, Optional, Any
 from signal import signal, SIGPIPE, SIG_DFL
 
-import datagristle.file_type as file_type
-import datagristle.csvhelper as csvhelper
-import datagristle.common as common
+from datagristle.common import abort
+import datagristle.file_io as file_io
+import datagristle.configulator as configulator
 
 # Ignore SIG_PIPE and don't throw exceptions on it...
 # (http://docs.python.org/library/signal.html)
 signal(SIGPIPE, SIG_DFL)
 
+NAME = basename(__file__)
+SHORT_HELP = 'Creates a frequency distribution of values from columns of the input file'
+
 
 
 def main() -> int:
-    """ Run the frequency distribution process in the following steps:
-        - get cmdline options & determine dialect
-        - build the freq distribution dictionary
-        - calculate field lengths for write formatting
-        - sort frequency distribution
-        - write dictionary to output
-    """
 
-    #----- initialize -----
-    cmd_parser = CommandLineParser()
-    opts = cmd_parser.opts
-    files = cmd_parser.files
-    dialect = get_dialect(opts, files)
+    args = get_args()
     return_code = 0 # success
 
-    # set up an array of sets of columns to process.
-    curr_col_set = []
-    if opts.col_type == 'each':
-        curr_col_set.append(0)      # special op - multiple runs
+    if args['col_type'] in ('each', 'all'):
+        col_set = [0]
     else:
-        curr_col_set = opts.columns # normal op - single run
+        col_set = args['columns']
 
-    # Run frequency processing in a loop - in case we have a columntype
-    # of 'each' - which requires a separate run for every column starting
-    # with the leftmost.  Other columntypes of 'specified' or 'all' will
-    # only go through this loop once.
+    # Run once for each col_set.  Only col_type of 'each' will have > 1 col_set,
+    # in which they'll run the following loop once for each column.  Other col_types
+    # will just run a single iteration of the loop.
+    total_read_cnt = 0
     while True:
-
-        #----- build the frequency distribution dictionary -----
-        col_freaker = ColFreaker(files,
-                                 dialect,
-                                 opts.col_type,
-                                 opts.number,
-                                 opts.sampling_method,
-                                 opts.sampling_rate,
-                                 opts.sortorder,
-                                 opts.sortcol,
-                                 opts.maxkeylen)
-        col_freaker.create_freq_from_column_set(curr_col_set)
-
-        #----- set up special column for 'each' columntype -----
-        if opts.col_type == 'each':
-            key_label = 'col:%03d - ' % curr_col_set[0]
-        else:
-            key_label = ''
-
-        #----- write sorted list to output -----
-        write_output(col_freaker.sort_freq,
-                     opts.output,
-                     col_freaker.col_len,
-                     opts.writelimit,
-                     key_label)
-
-
-        #----- handle looping -----
-        if col_freaker.truncated:
-            return_code = errno.ENOMEM # too many unique values
-            break
-        elif opts.col_type != 'each' and col_freaker.read_cnt == 0:
-            return_code = errno.ENODATA # empty file
-            break
-        elif col_freaker.sort_freq == []:
-            break # columntype 'each' just ran out of cols
-        elif opts.col_type == 'each':
-            curr_col_set[0] += 1  # columntype each has data
-        else:
-            break # non-'each' columntype - only runs once
-
-    return return_code # will be return code
-
-
-
-def get_dialect(opts, files: List[str]) -> csvhelper.Dialect:
-    """ Determine the csv dialect properties for the input file(s).
-        If there's only a single input file and the gristle_file_type module
-        was imported - then use that to determine csv dialect.  Otherwise, rely
-        on option input.
-    """
-    if len(files) == 1 and file_type:
-        my_file = file_type.FileTyper(files[0],
-                                      opts.delimiter,
-                                      opts.recdelimiter,
-                                      opts.has_header)
         try:
-            my_file.analyze_file()
-        except file_type.IOErrorEmptyFile:
-            # going to let this continue in order to handle messaging
-            # thru main
-            # all values are being set to defaults just to get csv reader to
-            # work - no actual data will be read
-            dialect = csvhelper.Dialect
-            dialect.quoting = csv.QUOTE_NONE
-            dialect.delimiter = ','
-            dialect.lineterminator = '\n'                 # naive assumption
+            input_handler = file_io.InputHandler(args['infiles'],
+                                                 args['delimiter'],
+                                                 args['quoting'],
+                                                 args['quotechar'],
+                                                 args['has_header'])
+        except EOFError:
+            print('Warning: empty file')
+            return errno.ENODATA # empty file
+        output_handler = file_io.OutputHandler(args['outfile'],
+                                               input_handler.dialect)
+
+        colset_freaker = ColSetFreaker(input_handler,
+                                       output_handler,
+                                       args['col_type'],
+                                       args['number'],
+                                       args['sampling_method'],
+                                       args['sampling_rate'],
+                                       args['sort_order'],
+                                       args['sort_col'],
+                                       args['max_key_len'])
+        colset_freaker.create_freq_from_column_set(col_set)
+        total_read_cnt += colset_freaker.read_cnt
+
+        colset_freaker.write_output(args['outfile'],
+                                    args['write_limit'],
+                                    col_set[0])
+
+        if colset_freaker.more_columns():   # col_type is 'each'
+            col_set[0] += 1
         else:
-            dialect = my_file.dialect
-    else:
-        # dialect parameters needed for stdin - since the normal code can't
-        # analyze this data.
-        dialect = csvhelper.Dialect
-        dialect.delimiter = opts.delimiter
-        dialect.quoting = csv.QUOTE_MINIMAL if opts.quoting else csv.QUOTE_NONE
-        dialect.quotechar = opts.quotechar
-        dialect.has_header = opts.has_header
-        dialect.lineterminator = '\n'                     # naive assumption
-    return dialect
+            if total_read_cnt == 0:
+                return_code = errno.ENODATA # 61: empty file
+            elif colset_freaker.truncated:
+                return_code = errno.ENOMEM  # 12: too many unique values
+            break
+
+        input_handler.close()
+        output_handler.close()
+
+
+    return return_code
 
 
 
 
 
-
-class ColFreaker(object):
+class ColSetFreaker(object):
 
     def __init__(self,
-                 files: List[str],
-                 dialect: csv.Dialect,
+                 input_handler,
+                 output_handler,
                  col_type: str,
                  number: int,
                  sampling_method: str,
@@ -197,8 +143,8 @@ class ColFreaker(object):
                  sort_col: int,
                  max_key_len: int) -> None:
 
-        self.files = files
-        self.dialect = dialect
+        self.input_handler = input_handler
+        self.output_handler = output_handler
         self.col_type = col_type
         self.number = number
         self.sampling_method = sampling_method
@@ -206,11 +152,12 @@ class ColFreaker(object):
         self.sort_order = sort_order
         self.sort_col = sort_col
         self.max_key_len = max_key_len
-        self.col_len = None
+        self.col_len_tracker = None
         self.field_freq = None
         self.sort_freq = None
         self.truncated: bool = None
         self.read_cnt = 0
+
 
     def create_freq_from_column_set(self, col_set: List[int]) -> None:
 
@@ -219,13 +166,14 @@ class ColFreaker(object):
 
         #----- sort the field_freq ------
         revorder = (True if self.sort_order == 'reverse' else False)
-        self.sort_freq = self._dict_sorter(self.field_freq, self.sort_col,
-                                           revorder)
+        self.sort_freq = sorted(self.field_freq.items(),
+                                key=operator.itemgetter(self.sort_col),
+                                reverse=revorder)
 
         #----- calculate field lengths for output formmating -----
-        self.col_len = ColumnLengthTracker()
-        self.col_len.add_all_values(self.sort_freq)
-        self.col_len.trunc_all_col_lengths(self.max_key_len)
+        self.col_len_tracker = ColumnLengthTracker()
+        self.col_len_tracker.add_all_values(self.sort_freq)
+        self.col_len_tracker.trunc_all_col_lengths(self.max_key_len)
 
 
     def build_freq(self, columns: List[int]) -> None:
@@ -243,39 +191,31 @@ class ColFreaker(object):
         self.field_freq = {}
         self.truncated = False
 
-        def read_recs(reader) -> None:
+        def process_rec(record: List[str]) -> None:
             nonlocal freq_cnt
-            for record in reader:
-                self.read_cnt += 1
-                if self.read_cnt == 1 and self.dialect.has_header:
-                    continue
-                if self.sampling_method == 'interval':
-                    if self.read_cnt % self.sampling_rate != 0:
-                        continue
-                key = self._create_key(record, columns)
-                if key:
-                    try:
-                        self.field_freq[key] += 1
-                    except KeyError:
-                        self.field_freq[key] = 1
-                        freq_cnt += 1
-                        if freq_cnt >= self.number:
-                            self.truncated = True
-                            print('WARNING: freq dict is too large - will truncate')
-                            break
+            self.read_cnt += 1
+            if self.read_cnt == 1 and self.input_handler.dialect.has_header:
+                return
+            if self.sampling_method == 'interval':
+                if self.read_cnt % self.sampling_rate != 0:
+                    return
+            key = self._create_key(record, columns)
+            if key:
+                try:
+                    self.field_freq[key] += 1
+                except KeyError:
+                    self.field_freq[key] = 1
+                    freq_cnt += 1
+                    if freq_cnt >= self.number:
+                        self.truncated = True
+                        print('WARNING: freq dict is too large - will truncate')
+                        raise TooLargeError
 
-        if self.files:
-            for filename in self.files:
-                with open(filename, 'rt', newline='', encoding='utf-8') as infile:
-                    reader = csv.reader(infile, dialect=self.dialect)
-                    read_recs(reader)
-        elif not os.isatty(0):
-            input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8', newline='')
-            reader = csv.reader(input_stream, dialect=self.dialect)
-            read_recs(reader)
-        else:
-            print('ERROR: no data found')
-
+        for rec in self.input_handler:
+            try:
+                process_rec(rec)
+            except TooLargeError:
+                break
 
 
     def _create_key(self,
@@ -300,30 +240,64 @@ class ColFreaker(object):
         return tuple(key)
 
 
+ 
+    def more_columns(self):
+        if self.col_type == 'each':
+            if self.sort_freq == []:   # columntype 'each' just ran out of cols
+                return False
+            else:
+                return True
+        else:
+            return False
 
-    @staticmethod
-    def _dict_sorter(field_freq: Dict[Tuple[str], int],
-                     sortcol: int,
-                     revorder: bool) -> common.FreqType:
-        """ Inputs:
-                - field_freq - a dictionary of tuples in which each tuple consists
-                                of two parts: a key tuple and value.
-                             - ex: {('8', 'A', 'B', 'C'): 1, ('30', 'A', 'B', 'C'): 1}
-                - sortcol    - indicates which column to sort - either 0 or 1
-                - revorder   - True indicates sorting in reverse order, False otherwise.
-            Output:
-                - a list of tuples - in which each tuple contains 2 items:
-                    - key - this is a tuple so it can handle multiple columns
-                    - count - number of times the key occurs
-                - ex: [(('8', 'A', 'B', 'C'), 1), (('30', 'A', 'B', 'C'), 1)]
-            Tested via test harness
+
+    def write_output(self,
+                     output: str,
+                     write_limit: int,
+                     col_set_num: int):
+        if output == '-':
+            outfile = sys.stdout
+            #outfile = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', newline='')
+        else:
+            outfile = open(output, 'a')
+
+        write_cnt = 0
+        for key_tup in self.sort_freq:
+            write_cnt += 1
+            if write_limit and write_cnt > write_limit:
+                break
+            row = self.create_output_row(key_tup, col_set_num)
+            outfile.write(row)
+
+        if output != '-':
+            outfile.close()
+
+
+    def create_output_row(self,
+                          freq_tup: Tuple[Tuple[str, ...], int],
+                          col_set_num: int) -> str:
+        """ input:
+            - freq_tup - is a tuple consisting of two entries: key & count.
+                Each key is also a tuple.  So it looks like this:
+                    (('key1a', 'key1b', 'key1c'), 5   )
+            output:
+            - an entire row to be written as output
+            tested via test-harness
         """
-        assert revorder in [True, False]
-        assert sortcol in [0, 1]
-        sort_freq = sorted(field_freq.items(),
-                           key=operator.itemgetter(sortcol),
-                           reverse=revorder)
-        return sort_freq
+        if self.col_type == 'each':
+            key_label = 'col:%03d - ' % col_set_num
+        else:
+            key_label = ''
+
+        key_part = ''
+        for colnum, key in enumerate(freq_tup[0]):
+            key_string = ' %-*.*s  - ' % (self.col_len_tracker.max_dict[colnum],
+                                          self.col_len_tracker.max_dict[colnum],
+                                          key)
+            key_part += key_string
+        row = '%s%s %s\n' % (key_label, key_part, freq_tup[1])
+        return row
+
 
 
 
@@ -379,279 +353,120 @@ class ColumnLengthTracker(object):
 
 
 
-def write_output(freq: common.FreqType,
-                 output: str,
-                 col_len: ColumnLengthTracker,
-                 write_limit: int,
-                 col_label: str = None):
-    """ freq input - is a list of tuples, each tuple must consist of
-        two entries: key & count.   Each key is also a tuple.
-                 [ (tup1),
-                   (tup2) ]
-        output - is the user-provided output filename
-        col_len - is an object that has the max lengths of all columns
-    """
-    if output == '-':
-        outfile = sys.stdout
-        #outfile = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', newline='')
-    else:
-        outfile = open(output, 'a')
-
-    write_cnt = 0
-    for key_tup in freq:
-        write_cnt += 1
-        if write_limit and write_cnt > write_limit:
-            break
-        row = create_output_row(key_tup, col_len, col_label)
-        outfile.write(row)
-
-    # don't close stdout
-    if output != '-':
-        outfile.close()
+class Configulator(configulator.Config):
+    def validate_custom_config(self, config: configulator.CONFIG_TYPE):
+       pass
 
 
+def get_args() -> Dict[str, Any]:
+    config_mgr = Configulator(NAME, SHORT_HELP, __doc__)
+    config_mgr.add_standard_config('infiles')
+    config_mgr.add_standard_config('outfile')
+    config_mgr.add_standard_config('delimiter')
+    config_mgr.add_standard_config('quoting')
+    config_mgr.add_standard_config('quotechar')
+    config_mgr.add_standard_config('escapechar')
+    config_mgr.add_standard_config('has_header')
+    config_mgr.add_standard_config('has_no_header')
+    config_mgr.add_custom_config(name='columns',
+                                 short_name='c',
+                                 arg_type='option',
+                                 default=None,
+                                 config_type=int,
+                                 nargs='*',
+                                 help_msg='Specify the columns to include via a comma-separated '
+                                          'list of columns.')
+    config_mgr.add_custom_config(name='col_type',
+                                 arg_type='option',
+                                 default='specified',
+                                 choices=['specified', 'all', 'each'],
+                                 config_type=str,
+                                 help_msg='Indicates how to process one or all columns')
+    config_mgr.add_custom_config(name='number',
+                                 short_name='n',
+                                 arg_type='option',
+                                 default=10_000_000,
+                                 config_type=int,
+                                 help_msg='Identifies the maximum number of items in frequency dictionary.   Default is 10m which would require approx 300 MB of mem to store 10 million 20 byte keys.')
+    config_mgr.add_custom_config(name='max_key_len',
+                                 arg_type='option',
+                                 config_type=int,
+                                 default=50,
+                                 help_msg='Identifies max length of key written to output.  Default is 50.')
+    config_mgr.add_custom_config(name='write_limit',
+                                 arg_type='option',
+                                 config_type=int,
+                                 default=0,
+                                 help_msg='Identifies max records to write.  Default of 0 indicates no limit.')
+    config_mgr.add_custom_config(name='sort_col',
+                                 arg_type='option',
+                                 config_type=int,
+                                 default=1,
+                                 help_msg='Specifies col to sort by - either 1 (count) or 0 (key). Default is 1')
+    config_mgr.add_custom_config(name='sort_order',
+                                 arg_type='option',
+                                 config_type=str,
+                                 choices=['forward', 'reverse'],
+                                 default='reverse',
+                                 help_msg='Specifies sort order of forward or reverse.  Default is reverse.')
+    config_mgr.add_custom_config(name='sampling_method',
+                                 arg_type='option',
+                                 config_type=str,
+                                 choices=['non', 'interval'],
+                                 default='non',
+                                 help_msg='Specifies which sampling method to use.  Choices are non (no sampling) or interval.  Default is non.')
+    config_mgr.add_custom_config(name='sampling_rate',
+                                 arg_type='option',
+                                 config_type=int,
+                                 default=None,
+                                 help_msg='Specifies number of records to skip if using interval sammpling-method.')
 
-def create_output_row(freq_tup: Tuple[Tuple[str, ...], int],
-                      col_len: ColumnLengthTracker,
-                      key_label: Optional[str]) -> str:
-    """ input:
-           - freq_tup - is a tuple consisting of two entries: key & count.
-             Each key is also a tuple.  So it looks like this:
-                  (('key1a', 'key1b', 'key1c'), 5   )
-           - col_len - is an object that has the max lengths of all columns
-           - key_label - first column only populated for 'each columntype
-        output:
-           - an entire row to be written as output
-        tested via test-harness
-    """
-    key_part = ''
-    for colnum, key in enumerate(freq_tup[0]):
-        key_string = ' %-*.*s  - ' % (col_len.max_dict[colnum],
-                                      col_len.max_dict[colnum],
-                                      key)
-        key_part += key_string
-    row = '%s%s %s\n' % (key_label, key_part, freq_tup[1])
-    return row
-
-
-
-class CommandLineParser(object):
-    """ Manages all parsing, formating and validating of command line options
-        and args.
-        Tested via test-harness.
-    """
-
-    def __init__(self) -> None:
-        use = ('%prog is used to print a frequency distribution of one or more'
-               'columns from the input file: \n'
-               '\n'
-               '   %prog [file] [misc options] '
-               '\n')
-        self.parser = optparse.OptionParser(usage=use)
-
-        self._define_parsers()
-        self.opts, self.files = self.parser.parse_args()
-
-        if self.opts.long_help:
-            print(__doc__)
-            sys.exit(0)
-
-        self._validate_sampling()
-        self._validate_misc()
-        self._format_columns()
-
-
-    def _define_parsers(self) -> None:
-        """ Define all cmdline parsers.
-        """
-        self.parser.add_option('--long-help',
-                               default=False,
-                               action='store_true',
-                               help='Print verbose help and exit.')
-
-        self.parser.add_option('-c', '--columns',
-                               type='string',# could be 1 or 3,10 or "15,20,21"
-                               help="One or many comma-separated column numbers to analyze."
-                                    "Are only used with default columntype of 'specified'.")
-
-        self.parser.add_option('--columntype',
-                               dest="col_type",
-                               choices=['specified', 'all', 'each'],
-                               default='specified',
-                               help='Indicates type of column processing:  '
-                                    'All == all columns are joined into a single concatenated '
-                                    'key.  '
-                                    'Each == each column is processed individually, and the '
-                                    'results are written to the same output file with along '
-                                    'with a column number prefix.'
-                                    'Specified == the typical use (and default) that indicates '
-                                    'that the user specified columns to operate upon.')
-
-        self.parser.add_option('-n', '--number',
-                               type=int,
-                               default=10000000,    # 10 million
-                               help='Specifies the max number of items in frequency dictionary.'
-                                    'Default is 10 million - expressed as 10000000.  This '
-                                    'results in approx 300 MBytes of memory used to store 10 '
-                                    'million 20 byte keys.')
-
-        self.parser.add_option('--maxkeylen',
-                               default=50,
-                               type=int,
-                               help='Specifies the maximum length of the key when written, not '
-                                    'when the data is collected.  The default is 50 chars.')
-
-        self.parser.add_option('--writelimit',
-                               type=int,
-                               default=0,
-                               help='Specifies a limit to the number of rows written. '
-                                    'The default of 0 indicates no limit.')
-
-        self.parser.add_option('--sortcol',
-                               type=int,
-                               default=1,
-                               #choices=[0, 1], # choices not allowed for type=int
-                               help='Specifies which column to sort by - 0 (key) or 1 (count). '
-                                    'The default is 1 (count). ')
-
-        self.parser.add_option('--sortorder',
-                               default='reverse',
-                               choices=['forward', 'reverse'],
-                               help='Specifies whether to sort the column in forward or reverse'
-                                    ' order. The default is reverse')
-
-        self.parser.add_option('--sampling_method',
-                               default='non',
-                               choices=['non', 'interval'],
-                               help='Specifies method of sampling to use.  Choices are non'
-                                    ' or interval.  Default is non.')
-
-        self.parser.add_option('--sampling_rate',
-                               default=None,
-                               type='float',
-                               help='Specifies which to use in frequency distribution. If the'
-                                    'method is interval, then this number describes how many'
-                                    'records to skip between each one to use.')
-
-        self.parser.add_option('-o', '--output',
-                               default='-',
-                               help="Specifies the output file, defaults to stdout indicated by"
-                                    " '-'.")
-
-        self.parser.add_option('-q', '--quiet',
-                               action='store_false',
-                               dest='verbose',
-                               default=True,
-                               help='provides less detail')
-
-        self.parser.add_option('-v', '--verbose',
-                               action='store_true',
-                               dest='verbose',
-                               default=True,
-                               help='provides more detail')
-
-        self.parser.add_option('-d', '--delimiter',
-                               help=('Specify a quoted single-column field delimiter. This may '
-                                     'be determined automatically by the program - unless you '
-                                     'pipe the data in.'))
-
-        self.parser.add_option('--quoting',
-                               default=False,
-                               action='store_true',
-                               help='Specify field quoting - generally only used for stdin '
-                                    'data.  The default is False.')
-
-        self.parser.add_option('--quotechar',
-                               default='"',
-                               help='Specify field quoting character - generally only used for '
-                                    'stdin data.  Default is double-quote')
-
-        self.parser.add_option('--recdelimiter',
-                               help='Specify quoted end-of-record delimiter.')
-
-        self.parser.add_option('--has-header',
-                               dest='has_header',
-                               default=None,
-                               action='store_true',
-                               help='indicates that there is a header in the file.')
-
-        self.parser.add_option('--has-no-header',
-                               dest='has_header',
-                               default=None,
-                               action='store_false',
-                               help=('Indicates that there is no header in the file.'
-                                     'Useful for overriding automatic csv dialect-guessing'
-                                     ' behavior.'))
+    config_mgr.process_configs()
+    validate_config(config_mgr.config)
+    return config_mgr.config
 
 
 
-    def _format_columns(self) -> None:
-        """ Converts input commma-delimited string into a list of integers.
-            Also validates columns vs columntype.
-        """
-        args: List[str] = []
-        valid: List[int] = []
-        if self.opts.columns:
-            if ',' in self.opts.columns:
-                args = self.opts.columns.split(',')
-            else:
-                args.append(self.opts.columns)
-        for arg in args:
-            try:
-                valid.append(int(arg))
-            except ValueError:
-                self.parser.error('Columns must consist only of comma-separated'
-                                  ' integers that refer to column offsets in'
-                                  ' source file')
-        self.opts.columns = valid
+
+def validate_config(config) -> None:
+
+    if config['columns'] is not None and config['col_type'] != 'specified':
+        abort('Columns can only be specified for col_type != specified.')
+    elif config['columns'] is None and config['col_type'] == 'specified':
+        abort("Columns must be provided for col_type of 'specified'.")
+
+    if config['number'] < 1000:
+        abort('Please provided a value between 1001 and 1000000000 for number')
+
+    if config['infiles'] != '-':
+        if len(config['infiles']) > 1 and not config['delimiter']:
+            abort('Please provide delimiter when piping or reading multiple input files')
+    else:   # stdin
+        if not config['delimiter']:
+            abort('Please provide delimiter when piping or reading multiple input files')
+
+    if config['sort_col'] not in (0, 1):
+        abort('Please provide a sortcol value of 0 or 1')
+
+    if 1 > config['max_key_len'] > 500:
+        abort('Please provide a maxkeylen > 0 and < 500')
 
 
-    def _validate_misc(self) -> None:
-        """  Perform validations on all columns
-        """
-        if self.opts.columns is not None and self.opts.col_type != 'specified':
-            self.parser.error('Columns can only be specified for columntype '
-                              '!= specified.')
-        elif self.opts.columns is None and self.opts.col_type == 'specified':
-            self.parser.error("Columns must be provided for columntype of "
-                              "'specified'.")
-
-        if self.opts.number < 1000:
-            self.parser.error('Please provided a value between 1001 and '
-                              '1000000000 for number')
-
-        if self.files:
-            if len(self.files) > 1 and not self.opts.delimiter:
-                self.parser.error('Please provide delimiter when piping data '
-                                  'into program via stdin or reading multiple '
-                                  'input files')
-        else:   # stdin
-            if not self.opts.delimiter:
-                self.parser.error('Please provide delimiter when piping data '
-                                  'into program via stdin or reading multiple '
-                                  'input files')
-        if self.opts.sortcol not in [0, 1]:
-            self.parser.error('Please provide a sortcol value of 0 or 1')
-
-        if 1 > self.opts.maxkeylen > 500:
-            self.parser.error('Please provide a maxkeylen > 0 and < 500')
+    if config['sampling_method'] == 'non':
+        if config['sampling_rate']:
+            abort('Sampling_rate must be left to default if sampling_method is "non"')
+    elif config['sampling_method'] == 'interval':
+        if config['sampling_rate']:
+            if config['sampling_rate'] != int(config['sampling_rate']):
+                abort('Inverval sampling rate must be an int')
+        else:
+            abort('Integer sampling_rate must be provided if sampling_method == "interval"')
 
 
-    def _validate_sampling(self) -> None:
-        """ Perform validation on the two sampling options.
-        """
-        if self.opts.sampling_method == 'non':
-            if self.opts.sampling_rate:
-                self.parser.error('Sampling_rate must be left to default if '
-                                  'sampling_method is "non"')
-        elif self.opts.sampling_method == 'interval':
-            if self.opts.sampling_rate:
-                if self.opts.sampling_rate != int(self.opts.sampling_rate):
-                    self.parser.error('Inverval sampling rate must be an int')
-            else:
-                self.parser.error('Integer sampling_rate must be provided if '
-                                  'sampling_method == "interval"')
 
+
+class TooLargeError(Exception):
+    pass
 
 
 

--- a/scripts/gristle_processor
+++ b/scripts/gristle_processor
@@ -58,7 +58,6 @@ def main():
             - processes directory
        Terminates program
     """
-    #----- set up ----
     args = get_args()
     config, config_fn = get_config(arg_config_file=args.config_file,
                                    arg_config_name=args.config_name)

--- a/scripts/gristle_slicer
+++ b/scripts/gristle_slicer
@@ -75,166 +75,90 @@
     Copyright 2011,2012,2013,2017 Ken Farmer
 """
 import sys
-import io
 import csv
 import fileinput
-import os
 from os.path import basename
 from pprint import pprint as pp
 from signal import signal, SIGPIPE, SIG_DFL
 from typing import List, Tuple, Dict, Any, Optional, IO
 
-import datagristle.file_type as file_type
 import datagristle.location_slicer as slicer
-import datagristle.csvhelper as csvhelper
 import datagristle.configulator as configulator
+import datagristle.file_io as file_io
 
 #Ignore SIG_PIPE and don't throw exceptions on it... (http://docs.python.org/library/signal.html)
 signal(SIGPIPE, SIG_DFL)
-
 
 NAME = basename(__file__)
 SHORT_HELP = 'Extract column and row subsets out of files using python string slicing notation\n'
 
 
+
 def main() -> int:
-    """ runs all processes:
-            - gets opts & args
-            - analyzes file to determine csv characteristics unless data is
-              provided via stdin
-            - runs each input record through process_cols to get output
-            - writes records
-    """
     config = get_args()
 
     try:
-        dialect = get_input_file_info(config['infiles'],
-                                      config['delimiter'],
-                                      config['quoting'],
-                                      config['quotechar'],
-                                      config['has_header'])
-    except file_type.IOErrorEmptyFile:
-        print('ERROR: empty file')
-        sys.exit(0)
-
-    outfile, writer = get_output_file_info(config['outfile'], dialect)
-
-    columns   = config['columns'].split(',')
-    excolumns = config['excolumns'].split(',') if config['excolumns'] else []
-    records   = config['records'].split(',')
-    exrecords = config['exrecords'].split(',') if config['exrecords'] else []
+        input_handler = file_io.InputHandler(config['infiles'],
+                                             config['delimiter'],
+                                             config['quoting'],
+                                             config['quotechar'],
+                                             config['has_header'])
+    except EOFError:
+        print('Warning: empty file')
+        return 0
 
     (incl_rec_slicer,
      excl_rec_slicer,
      incl_col_slicer,
-     excl_col_slicer) = setup_slicer(config['infiles'], dialect, records, exrecords, columns, excolumns)
+     excl_col_slicer) = setup_slicers(config['infiles'],
+                                      input_handler.dialect,
+                                      config['records'],
+                                      config['exrecords'],
+                                      config['columns'],
+                                      config['excolumns'])
 
-    rec_cnt = 0
-    if config['infiles'] == '-':
-        if not os.isatty(0):
-            input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8', newline='')
-            reader = csv.reader(input_stream, dialect=dialect)
-            processor(reader, writer, rec_cnt, incl_rec_slicer, excl_rec_slicer,
-                      incl_col_slicer, excl_col_slicer)
-        else:
-            print('ERROR: stdin but isatty!')
-            sys.exit(0)
-    else:
-        for infile in config['infiles']:
-            with open(infile, 'rt', newline='', encoding='utf-8') as inf:
-                reader = csv.reader(inf, dialect=dialect)
-                processor(reader, writer, rec_cnt, incl_rec_slicer, excl_rec_slicer,
-                          incl_col_slicer, excl_col_slicer)
+    output_handler = file_io.OutputHandler(config['outfile'], input_handler.dialect)
 
-    if config['outfile'] != '-':
-        outfile.close()
+    for rec_cnt, rec in enumerate(input_handler):
+        new_rec = process_rec(rec_cnt,
+                              incl_rec_slicer,
+                              excl_rec_slicer,
+                              rec,
+                              incl_col_slicer,
+                              excl_col_slicer)
+        if new_rec:
+            output_handler.write_rec(new_rec)
+
+    input_handler.close()
+    output_handler.close()
 
     return 0
 
 
 
-def processor(reader, writer, rec_cnt, incl_rec_slicer, excl_rec_slicer,
-              incl_col_slicer, excl_col_slicer) -> None:
-    try:
-        for rec in reader:
-            new_rec = process_rec(rec_cnt, incl_rec_slicer, excl_rec_slicer,
-                                  rec, incl_col_slicer, excl_col_slicer)
-            if new_rec:
-                write_rec(writer, new_rec, rec_cnt)
-            rec_cnt += 1
-    except file_type.IOErrorEmptyFile:
-        print('ERROR: empty file')
-        sys.exit(0)
-    return rec_cnt
 
-
-
-def get_input_file_info(infiles: List[str],
-                        delimiter: str,
-                        quoting: str,
-                        quotechar: str,
-                        has_header: bool) -> csvhelper.Dialect:
-    """ Sets up input files based upon options and files.
-
-        Supports manual csv dialect creation - which is necessary
-        for stdin or when file_type gets confused about a file format.
-        Manual csv dialect creation is triggered by the existance of
-        a delimiter in opts.
-
-        Otherwise, it will attempt to use the automatic dialect
-        detection - which only works for files passed in as args,
-        which show up here as the input arg files.
-    """
-    if delimiter:
-        dialect = csvhelper.Dialect(delimiter=delimiter,
-                                    has_header=has_header,
-                                    quoting=file_type.get_quote_number(quoting),
-                                    quotechar=quotechar,
-                                    lineterminator='\n')
-    else:
-        for infile in infiles:
-            my_file = file_type.FileTyper(infile)
-            try:
-                dialect = my_file.analyze_file()
-                break
-            except file_type.IOErrorEmptyFile:
-                raise
-
-    return dialect
-
-
-
-def get_output_file_info(outfile: str,
-                         dialect: csv.Dialect) -> Tuple[IO[Any], Any]:
-    """ Sets up output file based upon options:
-        Returns output file object
-    """
-    outfile_obj: IO[Any] = None
-    if outfile == '-':
-        outfile_obj = sys.stdout
-    else:
-        outfile_obj = open(outfile, "wt", encoding='utf-8')
-
-    writer = csv.writer(outfile_obj, dialect=dialect)
-    return outfile_obj, writer
-
-
-
-def setup_slicer(infiles: List[str],
-                 dialect: csv.Dialect,
-                 records: List[str],
-                 exrecords: List[str],
-                 columns: List[str],
-                 excolumns: List[str]) -> Tuple[slicer.SpecProcessor,
-                                                slicer.SpecProcessor,
-                                                slicer.SpecProcessor,
-                                                slicer.SpecProcessor]:
+def setup_slicers(infiles: List[str],
+                  dialect: csv.Dialect,
+                  config_records: str,
+                  config_exrecords: str,
+                  config_columns: str,
+                  config_excolumns: str) -> Tuple[slicer.SpecProcessor,
+                                                  slicer.SpecProcessor,
+                                                  slicer.SpecProcessor,
+                                                  slicer.SpecProcessor]:
     """  Sets up the 4 slicer objects: inclusion & exclusion for
          rec and column.
 
          Then counts records and columns if negative slice references
          exist and calls the spec adjuster.
     """
+
+    # first parse the config items;
+    columns   = config_columns.split(',')
+    excolumns = config_excolumns.split(',') if config_excolumns else []
+    records   = config_records.split(',')
+    exrecords = config_exrecords.split(',') if config_exrecords else []
+
     incl_rec_slicer = slicer.SpecProcessor(records,   'incl_rec_spec')
     excl_rec_slicer = slicer.SpecProcessor(exrecords, 'excl_rec_spec')
     incl_col_slicer = slicer.SpecProcessor(columns,   'incl_col_spec')
@@ -333,29 +257,6 @@ def process_rec(rec_number: int,
     else:
         return None  # don't return empty list
 
-
-
-# fixme: typing
-def write_rec(outfile: Any, fields: List[str], row_cnt: int) -> None:
-    """ Writes record to output object - using the same dialect as the input
-        file.
-        Input:
-            - output object
-            - list of fields to write
-        Output:
-            - delimited output record written to output object
-    """
-    try:
-        outfile.writerow(fields)
-    except csv.Error as e:
-        print('')
-        print('ERROR from csv module')
-        print('This could be a problem with dirty data.  Consider providing'
-              ' quoting and delimiter manually or inspecting file with'
-              ' gristle_validator.')
-        print('Error encountered on input row: %d (offset from 0)' % row_cnt)
-        print('')
-        raise
 
 
 

--- a/scripts/gristle_slicer
+++ b/scripts/gristle_slicer
@@ -119,8 +119,8 @@ def main() -> int:
 
     output_handler = file_io.OutputHandler(config['outfile'], input_handler.dialect)
 
-    for rec_cnt, rec in enumerate(input_handler):
-        new_rec = process_rec(rec_cnt,
+    for rec in input_handler:
+        new_rec = process_rec(input_handler.rec_cnt - 1,
                               incl_rec_slicer,
                               excl_rec_slicer,
                               rec,
@@ -277,6 +277,7 @@ def get_args() -> Dict[str, Any]:
     config_mgr.add_standard_config('quotechar')
     config_mgr.add_standard_config('escapechar')
     config_mgr.add_standard_config('has_header')
+    config_mgr.add_standard_config('has_no_header')
     config_mgr.add_custom_config(name='columns',
                                  short_name='c',
                                  arg_type='option',

--- a/scripts/gristle_validator
+++ b/scripts/gristle_validator
@@ -17,7 +17,6 @@ usage: gristle_validator [-h]
                          [-d DELIMITER]
                          [--quoting QUOTING]
                          [--quotechar QUOTECHAR]
-                         [--recdelimiter RECDELIMITER]
                          [--hasheader]
                          [--schemaid SCHEMA_ID]
                          [--validschema VALID_SCHEMA] [-s]
@@ -54,8 +53,6 @@ optional arguments:
   --quotechar QUOTECHAR
                         Specify field quoting character - generally only used
                         for stdin data.  Default is double-quote
-  --recdelimiter RECDELIMITER
-                        Specify a quoted end-of-record delimiter.
   --hasheader           Indicates that there is a header in the file.
                         Validation will mostly ignore the header.
   --hasnoheader         Indicates that there is no header in the file.
@@ -110,6 +107,7 @@ import yaml
 import datagristle.file_type as file_type
 import datagristle.common as common
 import datagristle.csvhelper as csvhelper
+import datagristle.file_io as file_io
 
 #--- Ignore SIG_PIPE and don't throw exceptions on it
 #--- (http://docs.python.org/library/signal.html)
@@ -127,22 +125,25 @@ def main() -> int:
     """
     args = get_args()
 
-    input_handler = InputHandler(args.files,
-                                 args.delimiter,
-                                 args.quoting,
-                                 args.quotechar,
-                                 args.recdelimiter,
-                                 args.hasheader)
-    outgood_handler = OutputHandler(input_handler.dialect,
-                                    args.outgood,
-                                    sys.stdout,
-                                    args.silent,
-                                    args.randomout)
-    outerr_handler = OutputHandler(input_handler.dialect,
-                                   args.outerr,
-                                   sys.stderr,
-                                   args.silent,
-                                   args.randomout)
+    try:
+        input_handler = file_io.InputHandler(args.files,
+                                            args.delimiter,
+                                            args.quoting,
+                                            args.quotechar,
+                                            args.hasheader)
+    except EOFError:
+        return errno.ENODATA  # is a 61 on linux
+
+    outgood_handler = file_io.OutputHandler(args.outgood,
+                                            input_handler.dialect,
+                                            sys.stdout,
+                                            args.silent,
+                                            args.randomout)
+    outerr_handler = file_io.OutputHandler(args.outerr,
+                                           input_handler.dialect,
+                                           sys.stderr,
+                                           args.silent,
+                                           args.randomout)
 
 
     rec_schema = load_schema(args.valid_schema)
@@ -155,12 +156,13 @@ def main() -> int:
                                       rec_validator,
                                       args.stats)
 
+    input_handler.close()
     outgood_handler.close()
     outerr_handler.close()
 
     if invalid_cnt > 0:
         return errno.EBADMSG  # is a 74 on linux
-    elif input_handler.rec_cnt == 0:
+    elif input_handler.rec_cnt == 0:  # catches empty stdin
         return errno.ENODATA  # is a 61 on linux
     else:
         return 0
@@ -200,10 +202,11 @@ def process_all_records(input_handler: 'InputHandler',
 
         if valid_rec:
             valid_cnt += 1
-            outgood_handler.write(rec)
+            outgood_handler.write_rec(rec)
         else:
             invalid_cnt += 1
-            outerr_handler.write(rec, common.coalesce(field_cnt_msg, schema_msg))
+            rec.append(common.coalesce(field_cnt_msg, schema_msg))
+            outerr_handler.write_rec(rec)
 
     write_stats(stats,
                 input_handler.rec_cnt,
@@ -233,121 +236,6 @@ def load_schema(schema_file: str) -> Optional[Dict[Any, Any]]:
         schema_dict = yaml.safe_load(schema_file)
     return schema_dict
 
-
-
-class OutputHandler(object):
-    """ Handles all aspects of writing to output files: opening file,
-        writing records, managing random writes, keeping counts,
-        closing the file, etc.
-    """
-
-    def __init__(self,
-                 dialect: csvhelper.Dialect,
-                 arg_output: str,
-                 default_output,
-                 silent: bool,
-                 randomout: int):
-        """ Performs initial housekeeping on output handling:
-               - validates args
-               - sets output to either stdout or a file
-               - sets up writing through cvs module.
-        """
-
-        assert silent in [True, False]
-        assert 100 >= randomout >= -1
-        self.silent = silent
-        self.randomout = randomout
-        if arg_output == '-':
-            self.outfile = default_output
-        else:
-            self.outfile = open(arg_output, "w")
-        self.writer = csv.writer(self.outfile, dialect=dialect)
-
-    def write(self, record: List[str], msg: str = None) -> None:
-        """ Write a record to output.
-            If silent arg was provided, then write is suppressed.
-            If randomout arg was provided, then randomly determine
-               whether or not to write record.
-        """
-        if self.silent:
-            return
-        if self.randomout > -1:
-            if random.randint(1, 100) > self.randomout:
-                return
-        if msg:
-            record.append(msg)
-
-        try:
-            self.writer.writerow(record)
-        except csv.Error:
-            print('Invalid record: %s' % record)
-            raise
-
-    def close(self):
-        self.outfile.close()
-
-
-
-
-class InputHandler(object):
-
-    def __init__(self,
-                 files: List[str],
-                 delimiter: Optional[str] = None,
-                 quoting: Optional[str] = None,
-                 quotechar: Optional[str] = None,
-                 recdelimiter: Optional[str] = None,
-                 hasheader: Optional[bool] = None):
-
-        self.files = files
-        self.files_read = 0
-        self.rec_cnt = 0
-        # look at updated code
-        # should probably do:
-        # a. use explicitely provided values if available
-        # b. use values from metadata if available
-        # c. use values from analysis of file - if len(files) == 1
-        #self.dialect = self._get_dialect(files, delimiter, quoting, quotechar,
-        #                                 recdelimiter, hasheader)
-        self.dialect = file_type.get_dialect(files,
-                                             delimiter,
-                                             quoting,
-                                             quotechar,
-                                             recdelimiter,
-                                             hasheader)
-        if files[0] == '-':
-            if os.isatty(0):  # checks if data was pipped into stdin
-                #raise ValueError, "No files or stdin provided"
-                sys.exit(errno.ENODATA)
-            else:
-                self.infile = sys.stdin
-                self.files_read = 1
-        else:
-            self.infile = open(files[0], 'r')
-            self.files_read = 1
-        self.csv_reader = csv.reader(self.infile, dialect=self.dialect)
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        """ Returns the next input record.   Can handle data piped in as well
-            as multiple input files.   All data is assumed to be csv files.
-        """
-        try:
-            rec = self.csv_reader.__next__()
-            self.rec_cnt += 1
-        except StopIteration:
-            if self.files_read < len(self.files): # another file to read!
-                self.files_read += 1
-                self.infile = self.files[self.files_read - 1]
-                self.csv_reader = csv.reader(self.infile, dialect=self.dialect)
-                rec = self.csv_reader.next()
-                self.rec_cnt += 1
-            else:
-                raise
-        else:
-            return rec
 
 
 
@@ -647,8 +535,6 @@ def get_args() -> argparse.Namespace:
                         default='"',
                         help='Specify field quoting character - generally only used for '
                              'stdin data.  Default is double-quote')
-    parser.add_argument('--recdelimiter',
-                        help='Specify a quoted end-of-record delimiter. ')
     parser.add_argument('--hasheader',
                         dest='hasheader',
                         default=None,
@@ -677,8 +563,8 @@ def get_args() -> argparse.Namespace:
                         action='store_true',
                         help='Causes pgm to print no stats, no valid or invalid recs.  Default is off.')
     parser.add_argument('--randomout',
-                        default=-1,
-                        type=int,
+                        default=1.0,
+                        type=float,
                         help='Causes pgm to write only a percentage of records out.')
     parser.add_argument('--errmsg',
                         default=False,
@@ -704,8 +590,8 @@ def get_args() -> argparse.Namespace:
         if len(args.files) > 1 and not args.delimiter:
             parser.error('Please provide delimiter when reading multiple input files')
 
-    if args.randomout > 100 or args.randomout < -1:
-        parser.error('Valid values for randomout are from 0 to 100')
+    if args.randomout > 1.0 or args.randomout < 0.0:
+        parser.error('Valid values for randomout are from 0.0 to 1.0')
 
 
     return args

--- a/scripts/gristle_viewer
+++ b/scripts/gristle_viewer
@@ -1,33 +1,27 @@
 #!/usr/bin/env python
-""" Displays a single record of a file, one field per line, with field names
-    displayed as labels to the left of the field values.  Also allows simple
-    navigation between records.
+""" Displays a single record of a file, pivoted with one field per line, with field names
+    displayed as labels to the left of the field values.  Also allows simple navigation
+    between records.
 
-    usage: View one record at a time from a csv formatted with headers
-
-        [-h] [-i [INFILES [INFILES ...]]] [-o OUTFILE] [-d DELIMITER]
-        [-q {quote_all,quote_minimal,quote_nonnumeric,quote_none}]
-        [--quotechar QUOTECHAR] [--escapechar ESCAPECHAR] [--has-header]
-        [-r RECNUM] [-V] [--long-help]
-
-    optional arguments:
+    arguments & options:
     -h, --help            show this help message and exit
     -i [INFILES [INFILES ...]], --infiles [INFILES [INFILES ...]]
-                            input filenames or default to for stdin
+                          input filenames or default to for stdin
     -o OUTFILE, --outfile OUTFILE
-                            output filename or '-' for stdout (the default)
+                          output filename or '-' for stdout (the default)
     -d DELIMITER, --delimiter DELIMITER
-                            csv delimiter
-    -q {quote_all,quote_minimal,quote_nonnumeric,quote_none}, --quoting {quote_all,quote_minimal,quote_nonnumeric,quote_none}
-                            csv quoting
+                          csv delimiter
+    -q {quote_all,quote_minimal,quote_nonnumeric,quote_none},
+    --quoting {quote_all,quote_minimal,quote_nonnumeric,quote_none}
+                          csv quoting
     --quotechar QUOTECHAR
-                            csv quotechar
+                          csv quotechar
     --escapechar ESCAPECHAR
-                            csv escapechar
+                          csv escapechar
     --has-header          csv dialect - indicates header exists
     -r RECNUM, --recnum RECNUM
-                            Displays this record number based on 0 offset,
-                            defaulting to 1
+                          Displays this record number based on 0 offset,
+                          defaulting to 1
     -V, --version         show version number then exit
     --long-help           Print more verbose help
 
@@ -53,8 +47,6 @@
 #       5.  improve error if no args provided - recommend -h for help
 
 import sys
-import csv
-import fileinput
 from os.path import basename
 from pprint import pprint as pp
 from typing import Dict, List, Optional, Any, Tuple
@@ -65,6 +57,7 @@ import datagristle.field_determinator  as field_determinator
 import datagristle.field_type as field_type
 import datagristle.configulator as configulator
 import datagristle.csvhelper as csvhelper
+import datagristle.file_io as file_io
 
 #Ignore SIG_PIPE and don't throw exceptions on it... (http://docs.python.org/library/signal.html)
 signal(SIGPIPE, SIG_DFL)
@@ -78,27 +71,31 @@ def main():
         navigation between records.
     """
     config = get_args()
-    try:
-        dialect, field_names = get_input_file_info(config['infiles'],
-                                                   config['delimiter'],
-                                                   config['quoting'],
-                                                   config['quotechar'],
-                                                   config['has_header'])
-    except file_type.IOErrorEmptyFile:
-        print('ERROR: empty file')
-        sys.exit(0)
+    field_names = None
 
     while True:
-        rec = get_rec(config['infiles'],
-                      config['recnum'],
-                      dialect)
-        if rec is None:
-            print('No record found')
-            return
+        try:
+            input_handler = file_io.InputHandler(config['infiles'],
+                                                 config['delimiter'],
+                                                 config['quoting'],
+                                                 config['quotechar'],
+                                                 config['has_header'])
+        except EOFError:
+            print('Warning: empty file')
+            return 0
+        else:
+            if not field_names:
+                field_names = get_field_names(config['infiles'], input_handler.dialect)
+            rec = get_rec(input_handler, config['recnum'])
+            input_handler.close()
+            if rec is None:
+                print('No record found')
+                return
 
-        display_rec(rec, field_names, config['outfile'])
+        output_handler = file_io.OutputHandler(config['outfile'], dialect=None)
+        display_rec(rec, field_names, output_handler)
+        output_handler.close()
 
-        # Need to end here if data is being directed to a file - and not interactive
         if config['outfile'] != '-':
             break
 
@@ -115,62 +112,29 @@ def main():
             config['recnum'] = int(response)
         else:
             print('Invalid response, please enter q, p, n, t, or a specific record number')
+    return 0
 
 
 
-def get_input_file_info(input_files: List[str],
-                        delimiter: str,
-                        quoting: str,
-                        quotechar: str,
-                        has_header: bool) -> Tuple[csvhelper.Dialect, List[str]]:
-    """ Gets information about csv dialect and field info from input files
-        and user-supplied options.
-
-        Supports manual csv dialect creation - which is necessary
-        if the automatic dialect detects gets confused about a file format.
-        Manual csv dialect creation is triggered by the existance of
-        a delimiter in opts.
-
-        Otherwise, it will attempt to use the automatic dialect
-        detection - which only works for files passed in as args,
-        which show up here as the input arg files.
-
-        Returns:
-            - dialect
-            - field_names
-        Raises:
-            - file_type.IOErrorEmptyFile
-    """
-    assert input_files
+def get_field_names(input_files, dialect):
 
     my_file = file_type.FileTyper(input_files[0],
-                                  delimiter=delimiter,
-                                  quoting=quoting)
-
-    if delimiter:
-        dialect = csvhelper.Dialect(delimiter=delimiter,
-                                    has_header=has_header,
-                                    quoting=file_type.get_quote_number(quoting),
-                                    quotechar=quotechar,
-                                    lineterminator='\n')
-        my_file.analyze_file()
-    else:
-        dialect = my_file.analyze_file()
-
+                                  delimiter=dialect.delimiter,
+                                  quoting=csvhelper.get_quote_name(dialect.quoting))
+    my_file.analyze_file()
     my_fields = field_determinator.FieldDeterminator(input_files[0],
                                                      my_file.format_type,
                                                      my_file.field_cnt,
                                                      dialect.has_header,
                                                      dialect)
     my_fields.analyze_fields()
-
-    return dialect, my_fields.field_names
+    return my_fields.field_names
 
 
 
 def display_rec(rec: str,
                 field_names: List[str],
-                outfile_name: str) -> None:
+                output_handler: file_io.OutputHandler):
     """ Displays a single record
     """
     # figure out label length for formatting:
@@ -185,24 +149,17 @@ def display_rec(rec: str,
             field_names.append('field_%d' % f_sub)
         min_format_len = 12
 
-    if outfile_name != '-':
-        outfile = open(outfile_name, 'w')
-    else:
-        outfile = sys.stdout
-
     # write in column order:
     for f_sub in range(len(rec)):
         try:
-            outfile.write('%-*s  -  %-40s\n' % (min_format_len, field_names[f_sub], rec[f_sub]))
+            output_handler.write_text_rec('%-*s  -  %-40s\n' % (min_format_len, field_names[f_sub], rec[f_sub]))
         except KeyError:
-            outfile.write('*** Missing Field - possibly due to csv parsing issues ***\n')
-
-    if outfile_name != '-':
-        outfile.close()
+            output_handler.write_text_rec('*** Missing Field - possibly due to csv parsing issues ***\n')
 
 
 
-def get_rec(files: List[str], recnum: int, dialect: csv.Dialect) -> Optional[List[Any]]:
+
+def get_rec(input_handler, recnum: int) -> Optional[List[Any]]:
     """ Gets a single record from a file
         Since it reads from the begining of the file it can take a while to get
         to records at the end of a large file
@@ -212,19 +169,21 @@ def get_rec(files: List[str], recnum: int, dialect: csv.Dialect) -> Optional[Lis
            - possibly keep some of the data in a dictionary in case the user
              wants to navigate about
     """
-    found = None
-    for row in csv.reader(fileinput.input(files), dialect):
-        if fileinput.lineno() == recnum+1:
-            found = row
+    for row in input_handler:
+        if input_handler.rec_cnt == recnum+1:
+            result = row
             break
-    fileinput.close()
-    return found
+    else:
+        result = None
+    return result
+
 
 
 class ViewerConfigulator(configulator.Config):
     def validate_custom_config(self, config: configulator.CONFIG_TYPE):
         if config['infiles'] == '-':
             self.parser.error('An input filename is required')
+
 
 
 def get_args() -> Dict[str, Any]:

--- a/scripts/tests/test_gristle_freaker_slow.py
+++ b/scripts/tests/test_gristle_freaker_slow.py
@@ -14,14 +14,13 @@ import random
 import csv
 import os
 from os.path import dirname, join as pjoin
+from pprint import pprint as pp
 
 import datagristle.test_tools as test_tools
+import datagristle.file_io as file_io
 
 pgm_path = dirname(dirname(os.path.realpath((__file__))))
 mod = test_tools.load_script(pjoin(pgm_path, 'gristle_freaker'))
-
-
-RECORD_NUMBER = 1000000   # 1 Million
 
 
 
@@ -29,57 +28,48 @@ RECORD_NUMBER = 1000000   # 1 Million
 class Test_build_freq(object):
 
     def setup_method(self, method):
-        self.dialect = csv.Dialect
-        self.dialect.delimiter = '|'
-        self.dialect.quoting = csv.QUOTE_MINIMAL
-        self.dialect.quotechar = '"'
-        self.dialect.has_header = False
-        self.dialect.lineterminator = '\n'
-        self.files = []
-        self.files.append(generate_test_file(self.dialect.delimiter, RECORD_NUMBER))
-        self.columns = [1, 2]
-        self.number = RECORD_NUMBER
+        pass
 
     def teardown_method(self, method):
         test_tools.temp_file_remover(os.path.join(tempfile.gettempdir(), 'FreakerTest'))
 
     def test_multicol(self):
-        col_type = 'specified'
-        sampling_method = 'non'
-        sampling_rate = None
-        sortorder = 'reverse'
-        sortcol = 1
-        maxkeylen = 50
-        col_freak = mod.ColFreaker(self.files, self.dialect, col_type,
-                                   self.number,
-                                   sampling_method, sampling_rate,
-                                   sortorder, sortcol, maxkeylen)
-        col_freak.build_freq(self.columns)
+
+        dialect = csv.Dialect
+        dialect.delimiter = '|'
+        dialect.quoting = csv.QUOTE_MINIMAL
+        dialect.quotechar = '"'
+        dialect.has_header = False
+        dialect.lineterminator = '\n'
+        columns = [1, 2]
+        files = []
+        files.append(generate_test_file(dialect.delimiter, 10_000_000))
+        (fd, outfile) = tempfile.mkstemp(prefix='FreakerTestOut_')
+        input_handler = file_io.InputHandler(files,
+                                             dialect.delimiter,
+                                             dialect.quoting,
+                                             dialect.quotechar,
+                                             dialect.has_header)
+        output_handler = file_io.OutputHandler(outfile,
+                                               input_handler.dialect)
+
+        col_freak = mod.ColSetFreaker(input_handler,
+                                      output_handler,
+                                      col_type='specified',
+                                      number=20_000_000,
+                                      sampling_method='non',
+                                      sampling_rate=None,
+                                      sort_order='reverse',
+                                      sort_col=1,
+                                      max_key_len=50)
+        col_freak.build_freq(columns)
         assert not col_freak.truncated
-        assert sum(col_freak.field_freq.values()) == RECORD_NUMBER
-        assert len(col_freak.field_freq) == 8
+        pp(col_freak.field_freq)
+        assert sum(col_freak.field_freq.values()) == 10_000_000
         for key in col_freak.field_freq.keys():
             assert key[0] in ['A1', 'A2', 'A3', 'A4']
             assert key[1] in ['B1', 'B2']
 
-
-
-def generate_col_freaker_dependencies():
-    dialect = csv.Dialect
-    dialect.delimiter = '|'
-    dialect.quoting = csv.QUOTE_MINIMAL
-    dialect.quotechar = '"'
-    dialect.has_header = False
-    dialect.lineterminator = '\n'
-    files = []
-    files.append(generate_test_file(dialect.delimiter, 1000))
-    columns = [1, 2]
-    number = 1000
-    col_type = 'specified'
-    sampling_method = 'non'
-    sampling_rate = None
-    number = 4
-    return files, dialect, col_type, number, sampling_method, sampling_rate, columns
 
 
 def generate_test_file(delim, record_cnt):

--- a/scripts/tests/test_gristle_slicer_cmd.py
+++ b/scripts/tests/test_gristle_slicer_cmd.py
@@ -107,7 +107,7 @@ class Test7x7File(object):
         valid.append('0-0,0-1,0-2,0-3,0-4,0-5,0-6')
 
         actual = self.runner('-r 0', None, None, None,
-                             options='''--delimiter=',' --quoting=quote_none''')
+                             options='''--delimiter=',' --quoting=quote_none --has-no-header''')
         assert valid == actual
 
     def test_select_first_col(self):

--- a/scripts/tests/test_gristle_validator_cmd.py
+++ b/scripts/tests/test_gristle_validator_cmd.py
@@ -368,7 +368,7 @@ class TestFieldCount(object):
         assert valid_cnt_found
 
 
-    def test_randomout_100(self):
+    def test_randomout_1(self):
         in_fqfn = _generate_foobarbatz_file(10000, dir_name=self.tmp_dir)
         self.cmd = """%(pgm)s %(in_fqfn)s          \
                          -d ','                    \
@@ -376,7 +376,7 @@ class TestFieldCount(object):
                          --quoting 'quote_none'    \
                          --outgood %(outgood)s     \
                          --outerr  %(outerr)s      \
-                         --randomout 100           \
+                         --randomout 1.0           \
                    """ % {'pgm':     self.pgm,
                           'outgood': self.outgood_fqfn,
                           'outerr':  self.outerr_fqfn,
@@ -416,7 +416,7 @@ class TestFieldCount(object):
         assert not self.good_output
 
 
-    def test_randomout_10(self):
+    def test_randomout_01(self):
 
         in_fqfn = _generate_foobarbatz_file(10000, dir_name=self.tmp_dir)
         self.cmd = """%(pgm)s %(in_fqfn)s          \
@@ -425,7 +425,7 @@ class TestFieldCount(object):
                          --quoting 'quote_none'    \
                          --outgood %(outgood)s     \
                          --outerr  %(outerr)s      \
-                         --randomout 10            \
+                         --randomout 0.1           \
                    """ % {'pgm':     self.pgm,
                           'outgood': self.outgood_fqfn,
                           'outerr':  self.outerr_fqfn,


### PR DESCRIPTION
This change provides simplified and more robust argument handling and file_io than was previously used.   

It isn't rolled-out to all utilities, just freaker, slicer, validator, and viewer.

For these we get better consistency, but there are some breaking changes.  These mostly involve slightly different arguments (ex: sort-order instead of sortorder or sort_order), or slightly different handling of io edge cases (like support for multiple empty files then a populated one).