### PR TITLE
pip 10 additional support - update cletus version requirement, etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.1.5 - 2018-05
+   * fixed setup.py bug in which pip10 no longer includes req module
+
 # v0.1.4 - 2017-12
    * fixed gristle_validator bug in which checks on dg_maximum were not being run
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+v0.1.5 - 2018-05
+================
+
+-  fixed setup.py bug in which pip10 no longer includes req module
+
 v0.1.4 - 2017-12
 ================
 

--- a/datagristle/_version.py
+++ b/datagristle/_version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ PyYAML      == 3.11
 SQLAlchemy  == 0.9.8
 Werkzeug    == 0.9.6
 appdirs     == 1.4.3
-cletus      == 1.0.14
+cletus      == 1.0.15
 envoy       == 0.0.3
 pytest      == 3.1.2
 validictory == 1.0.0

--- a/setup.py
+++ b/setup.py
@@ -5,27 +5,17 @@ import uuid
 from setuptools import setup, find_packages
 
 def read(*paths):
-    """Build a file path from *paths* and return the contents."""
     with open(os.path.join(*paths), 'r') as f:
         return f.read()
 
-def read_version():
-    rec = read('datagristle/_version.py')
-    fields = rec.split('=')
-    version = fields[1].strip()[1:-1]
-    assert version.count('.') == 2
-    return version
-
-
-version = read_version()
+VERSION = read('datagristle/_version.py').split('=')[1].strip()[1:-1]
+REQUIREMENTS = read('requirements.txt')
 DESCRIPTION = 'A toolbox and library of ETL, data quality, and data analysis tools'
 
-with open("requirements.txt") as reqs_file:
-    REQUIREMENTS = reqs_file.readlines()
-
+assert VERSION.count('.') == 2
 
 setup(name='datagristle',
-      version=version,
+      version=VERSION,
       description=DESCRIPTION,
       long_description=(read('README.rst') + '\n\n' + read('CHANGELOG.rst')),
       keywords="data analysis quality utility etl",

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py36
 # pycov has some version conflicts, so taking this out for now
 #commands=py.test {posargs} --cov=./scripts --cov-report=term
 commands=py.test {posargs} 
-deps= -irrequirements.txt
+deps= -r{toxinidir}/requirements.txt
 
 [pytest]
 python_files  = test_*.py


### PR DESCRIPTION
pip 10 eliminated pip.req module, this change removes its usage from setup.py as well as requires an updated version of cletus which does the same.