### PR TITLE
Add file_sorter library & gristle_sorter cli

### DIFF
--- a/datagristle/tests/test_file_sorter.py
+++ b/datagristle/tests/test_file_sorter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """ See the file "LICENSE" for the full license governing this code.
-    Copyright 2015,2017 Ken Farmer
+    Copyright 2020 Ken Farmer
 """
 #adjust pylint for pytest oddities:
 #pylint: disable=missing-docstring
@@ -9,10 +9,11 @@
 #pylint: disable=protected-access
 #pylint: disable=no-self-use
 
-import tempfile
-import shutil
-import fileinput
 import csv
+import fileinput
+from pprint import pprint as pp
+import shutil
+import tempfile
 from os.path import dirname, basename
 from os.path import join as pjoin
 
@@ -20,6 +21,283 @@ import pytest
 
 import datagristle.file_sorter as mod
 import datagristle.csvhelper as csvhelper
+
+
+
+class TestSortKeyRecord(object):
+
+    def test_happypath(self):
+        sort_key_rec= mod.SortKeyRecord('5sr')
+        assert sort_key_rec.position == 5
+        assert sort_key_rec.type == 'str'
+        assert sort_key_rec.order == 'reverse'
+
+    def test_case(self):
+        sort_key_rec= mod.SortKeyRecord('5SR')
+        assert sort_key_rec.position == 5
+        assert sort_key_rec.type == 'str'
+        assert sort_key_rec.order == 'reverse'
+
+    def test_big_position(self):
+        sort_key_rec= mod.SortKeyRecord('99SR')
+        assert sort_key_rec.position == 99
+        assert sort_key_rec.type == 'str'
+        assert sort_key_rec.order == 'reverse'
+
+    def test_all_types(self):
+        sort_key_rec= mod.SortKeyRecord('99SR')
+        assert sort_key_rec.type == 'str'
+
+        sort_key_rec= mod.SortKeyRecord('99iR')
+        assert sort_key_rec.type == 'int'
+
+        sort_key_rec= mod.SortKeyRecord('99fR')
+        assert sort_key_rec.type == 'float'
+
+    def test_all_orders(self):
+        sort_key_rec= mod.SortKeyRecord('99SR')
+        assert sort_key_rec.order == 'reverse'
+
+        sort_key_rec= mod.SortKeyRecord('99if')
+        assert sort_key_rec.order == 'forward'
+
+    def test_invalid_position(self):
+        with pytest.raises(ValueError):
+            sort_key_rec= mod.SortKeyRecord('bSR')
+
+    def test_invalid_type(self):
+        with pytest.raises(ValueError):
+            sort_key_rec= mod.SortKeyRecord('99R')
+
+    def test_invalid_order(self):
+        with pytest.raises(ValueError):
+            sort_key_rec= mod.SortKeyRecord('9i9')
+
+
+
+class TestSortkeysConfig(object):
+
+    def test_one_key(self):
+        sort_keys = mod.SortKeysConfig(['1sf'])
+        assert sort_keys.key_fields == [mod.SortKeyRecord('1sf')]
+
+    def test_two_keys(self):
+        sort_keys = mod.SortKeysConfig(['1sf','2ir'])
+        assert sort_keys.key_fields == [mod.SortKeyRecord('1sf'), mod.SortKeyRecord('2ir')]
+
+    def test_multi_string_orders(self):
+        sort_keys = mod.SortKeysConfig(['1sf','2sr'])
+        assert sort_keys.multi_string_orders() is True
+
+        sort_keys = mod.SortKeysConfig(['1sf','2sf'])
+        assert sort_keys.multi_string_orders() is False
+
+    def test_get_primary_order(self):
+        sort_keys = mod.SortKeysConfig(['1sf','2ir'])
+        assert sort_keys.get_primary_order() == 'forward'
+
+        sort_keys = mod.SortKeysConfig(['1sr','2sr'])
+        assert sort_keys.get_primary_order() == 'reverse'
+
+        sort_keys = mod.SortKeysConfig(['1ir'])
+        assert sort_keys.get_primary_order() == 'reverse'
+
+    def test_get_sort_fields(self):
+        sort_keys = mod.SortKeysConfig(['1sf','2ir'])
+        assert sort_keys.get_sort_fields() == [0,1]
+
+
+
+class TestCSVPythonSorter(object):
+
+    def setup_method(self, method):
+        self.temp_dir = tempfile.mkdtemp(prefix='gristle_test_')
+        self.dialect = csvhelper.Dialect(delimiter=',', quoting=csv.QUOTE_NONE, has_header=False)
+        self.fqfn  = create_test_file(self.temp_dir)
+        self.out_dir = tempfile.mkdtemp(prefix='gristle_out_')
+
+    def teardown_method(self, method):
+        shutil.rmtree(self.temp_dir)
+        shutil.rmtree(self.out_dir)
+
+    def test_sort_file_string(self):
+        out_fqfn = self.fqfn + '.sorted'
+        sort_keys_config = mod.SortKeysConfig(['0sf'])
+        sorter = mod.CSVPythonSorter(self.fqfn, out_fqfn, sort_keys_config, self.dialect, dedupe=False)
+        stats = sorter.sort_file()
+        pp(sorter.stats)
+        sorter.close()
+        with open(out_fqfn, newline='') as buf:
+            reader = csv.reader(buf)
+            data = list(reader)
+        pp(data)
+        assert data[0][0] == '1'
+        assert data[1][0] == '2'
+        assert data[2][0] == '3'
+        assert data[3][0] == '4'
+
+    def test_sort_file_numeric(self):
+        out_fqfn = self.fqfn + '.sorted'
+        sort_keys_config = mod.SortKeysConfig(['0if'])
+        sorter = mod.CSVPythonSorter(self.fqfn, out_fqfn, sort_keys_config, self.dialect, dedupe=False)
+        stats = sorter.sort_file()
+        pp(sorter.stats)
+        sorter.close()
+        with open(out_fqfn, newline='') as buf:
+            reader = csv.reader(buf)
+            data = list(reader)
+        pp(data)
+        assert data[0][0] == '1'
+        assert data[1][0] == '2'
+        assert data[2][0] == '3'
+        assert data[3][0] == '4'
+
+    def test_sort_file_reverse(self):
+        out_fqfn = self.fqfn + '.sorted'
+        sort_keys_config = mod.SortKeysConfig(['0ir'])
+        sorter = mod.CSVPythonSorter(self.fqfn, out_fqfn, sort_keys_config, self.dialect, dedupe=False)
+        stats = sorter.sort_file()
+        pp(sorter.stats)
+        sorter.close()
+        with open(out_fqfn, newline='') as buf:
+            reader = csv.reader(buf)
+            data = list(reader)
+        pp(data)
+        assert data[0][0] == '4'
+        assert data[1][0] == '3'
+        assert data[2][0] == '2'
+        assert data[3][0] == '1'
+
+    def test_sort_file_dedupe(self):
+        self.fqfn  = create_test_file(self.temp_dir, duplicate=True)
+        out_fqfn = self.fqfn + '.sorted'
+        sort_keys_config = mod.SortKeysConfig(['0ir'])
+        sorter = mod.CSVPythonSorter(self.fqfn, out_fqfn, sort_keys_config, self.dialect, dedupe=True)
+        stats = sorter.sort_file()
+        pp(sorter.stats)
+        sorter.close()
+        with open(out_fqfn, newline='') as buf:
+            reader = csv.reader(buf)
+            data = list(reader)
+        pp(data)
+        assert sorter.stats['recs_read'] == 5
+        assert sorter.stats['recs_written'] == 4
+        assert sorter.stats['recs_deduped'] == 1
+        assert data[0][0] == '4'
+        assert data[1][0] == '3'
+        assert data[2][0] == '2'
+        assert data[3][0] == '1'
+
+    def test_header(self):
+        self.fqfn  = create_test_file(self.temp_dir, header=True)
+        self.dialect.has_header = True
+        out_fqfn = self.fqfn + '.sorted'
+        sort_keys_config = mod.SortKeysConfig(['0if'])
+        sorter = mod.CSVPythonSorter(self.fqfn, out_fqfn, sort_keys_config, self.dialect, dedupe=True)
+        stats = sorter.sort_file()
+        pp(sorter.stats)
+        sorter.close()
+        with open(out_fqfn, newline='') as buf:
+            reader = csv.reader(buf)
+            data = list(reader)
+        pp(data)
+        assert sorter.stats['recs_read'] == 5
+        assert sorter.stats['recs_written'] == 5
+        assert sorter.stats['recs_deduped'] == 0
+        assert data[0][0] == 'num'
+        assert data[1][0] == '1'
+        assert data[2][0] == '2'
+        assert data[3][0] == '3'
+        assert data[4][0] == '4'
+
+
+    def test_get_sort_values_happy_path(self):
+        self.fqfn  = create_test_file(self.temp_dir, header=True)
+        self.dialect.has_header = True
+        out_fqfn = self.fqfn + '.sorted'
+        sort_keys_config = mod.SortKeysConfig(['0sf'])
+        sorter = mod.CSVPythonSorter(self.fqfn, out_fqfn, sort_keys_config, self.dialect, dedupe=True)
+
+        rec = ['foo', 3, 'bar', 9]
+        primary_order = 'forward'
+        assert sorter._get_sort_values(sort_keys_config.key_fields, rec, primary_order) == ['foo']
+
+
+    def test_get_sort_values_(self):
+        self.fqfn = create_test_file(self.temp_dir, header=True)
+        self.dialect.has_header = True
+        out_fqfn = self.fqfn + '.sorted'
+        sort_keys_config = mod.SortKeysConfig(['0sf', '1ir'])
+        sorter = mod.CSVPythonSorter(self.fqfn, out_fqfn, sort_keys_config, self.dialect, dedupe=True)
+
+        rec = ['foo', 3, 'bar', 9]
+        primary_order = 'forward'
+        pp(sorter._get_sort_values(sort_keys_config.key_fields, rec, primary_order))
+        assert sorter._get_sort_values(sort_keys_config.key_fields, rec, primary_order) == ['foo', -3]
+
+
+
+class TestIsDuplicate(object):
+
+    def test_deduper(self):
+
+        assert not mod.isduplicate('a')
+        assert not mod.isduplicate('b')
+        assert not mod.isduplicate('c')
+        assert mod.isduplicate('c')
+        assert mod.isduplicate('c')
+        assert not mod.isduplicate('d')
+
+    def test_deduper_with_tuple_input(self):
+
+        assert not mod.isduplicate(('a',))
+        assert not mod.isduplicate(('b',))
+        assert not mod.isduplicate(('c',))
+        assert mod.isduplicate(('c',))
+        assert mod.isduplicate(('c',))
+        assert not mod.isduplicate(('d',))
+
+
+
+class TestTransform(object):
+
+    def test_string(self):
+        sort_key_rec = mod.SortKeyRecord('2sf')
+        assert mod.transform('foo', sort_key_rec, 'forward') == 'foo'
+
+    def test_integer(self):
+        sort_key_rec = mod.SortKeyRecord('2if')
+        assert mod.transform('3', sort_key_rec, 'forward') == 3
+
+    def test_integer_reversed(self):
+        sort_key_rec = mod.SortKeyRecord('2ir')
+        assert mod.transform('3', sort_key_rec, 'forward') == -3
+
+    def test_integer_reversed_but_primary_is_already_reverse(self):
+        sort_key_rec = mod.SortKeyRecord('2ir')
+        assert mod.transform('3', sort_key_rec, 'reversed') == 3
+
+    def test_float(self):
+        sort_key_rec = mod.SortKeyRecord('2ff')
+        assert mod.transform('3.2', sort_key_rec, 'forward') == 3.2
+
+    def test_float_reversed(self):
+        sort_key_rec = mod.SortKeyRecord('2fr')
+        assert mod.transform('3.2', sort_key_rec, 'forward') == -3.2
+
+    def test_float_reversed_but_primary_is_already_reverse(self):
+        sort_key_rec = mod.SortKeyRecord('2fr')
+        assert mod.transform('3.2', sort_key_rec, 'reversed') == 3.2
+
+    def test_string_reversed(self):
+        sort_key_rec = mod.SortKeyRecord('2sr')
+        assert mod.transform('3.2', sort_key_rec, 'forward') == '3.2'
+
+    def test_string_reversed_but_primary_is_already_reverse(self):
+        sort_key_rec = mod.SortKeyRecord('2sr')
+        assert mod.transform('3.2', sort_key_rec, 'reversed') == '3.2'
+
+
 
 
 class TestSort(object):
@@ -143,13 +421,17 @@ class TestSort(object):
         assert basename(outfile) == basename(self.fqfn) + '.sorted'
 
 
-def create_test_file(temp_dir, delimiter=','):
+def create_test_file(temp_dir, delimiter=',', duplicate=False, header=False):
     fqfn = pjoin(temp_dir, 'foo.csv')
     with open(fqfn, 'w') as f:
+        if header:
+            f.write(delimiter.join(['num', 'alpha', 'alphanumeric']) + '\n')
         f.write(delimiter.join(['4', 'aaa', 'a23']) + '\n')
         f.write(delimiter.join(['2', 'bbb', 'a23']) + '\n')
         f.write(delimiter.join(['1', 'bbb', 'b23']) + '\n')
         f.write(delimiter.join(['3', 'aaa', 'b23']) + '\n')
+        if duplicate:
+            f.write(delimiter.join(['3', 'aaa', 'b23']) + '\n')
     return fqfn
 
 

--- a/scripts/gristle_sorter
+++ b/scripts/gristle_sorter
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+"""
+"""
+import sys
+import argparse
+from pprint import pprint as pp
+import errno
+from typing import Dict, List, Any, Optional, Union
+
+from signal import signal, SIGPIPE, SIG_DFL
+
+import datagristle.csvhelper as csvhelper
+import datagristle.file_sorter as file_sorter
+
+#--- Ignore SIG_PIPE and don't throw exceptions on it
+#--- (http://docs.python.org/library/signal.html)
+signal(SIGPIPE, SIG_DFL)
+
+
+
+def main() -> int:
+    """ runs all processes:
+            - gets args
+            - analyzes file to determine csv characteristics unless data is
+              provided via stdin
+            - runs each input record through process_cols to get output
+            - writes records
+    """
+    try:
+        config_manager = ConfigManager()
+        config = config_manager.get_config()
+    except EOFError:
+        sys.exit(errno.ENODATA) # 61: empty file
+
+    sorter = file_sorter.CSVPythonSorter(config.infile,
+                                         config.outfile,
+                                         config.sort_keys,
+                                         config.dialect,
+                                         config.dedupe)
+
+    sorter.sort_file()
+    sorter.close()
+
+
+
+class ConfigManager(object):
+
+    def __init__(self):
+        self.config = None
+
+    def get_config(self) -> argparse.Namespace:
+        self.get_user_config()
+        self.validate_user_config()
+        self.extend_config()
+        return self.config
+
+    def get_user_config(self) -> None:
+        """ gets args and returns them
+            Input:
+                - command line args & options
+            Output:
+                - args dictionary
+        """
+        use = ("%prog is used to validate the number of fields in a file. It "
+               "writes records with a fieldcnt other than provided to output "
+               "file or stdout \n"
+               " \n"
+               "   %prog [file] [misc options]")
+        self.parser = argparse.ArgumentParser(description=use,
+                                              formatter_class=argparse.RawTextHelpFormatter)
+
+        self.parser.add_argument('-i', '--infile',
+                                 default='-',
+                                 help='Specifies the input file.  The default is stdin.')
+        self.parser.add_argument('-o', '--outfile',
+                                 default='-',
+                                 help='Specifies the output file.  The default is stdout.  Note that'
+                                      'if a filename is provided the program will override any '
+                                      'file of that name.')
+        self.parser.add_argument('-D', '--dedupe',
+                                 default=False,
+                                 action='store_true',
+                                 help='Directs program to remove duplicates - based on the key provided. '
+                                      'Note that this will treat 0 and 0.0 the same if the keys are specified '
+                                      'as numeric. '
+                                      'However, case differences will not be ignored.')
+        self.parser.add_argument('-k', '--keys',
+                                 required=True,
+                                 nargs='+',
+                                 help='Specifies the key configuration. Each key specified consists of three values: '
+                                      '1) position (0-offset), 2) type (s=string, i=integer, f=float), '
+                                      '3) order (f=forward, r=reverse). '
+                                      'All 3 values are required for each key.  Multiple keys can be specified by '
+                                      'separating groups of 3 with a comma or including all within quotes and '
+                                      'separating the groups with a space.')
+
+        self.parser.add_argument('-d', '--delimiter',
+                                 help=('Specify a quoted single-column field delimiter. This may be'
+                                       'determined automatically by the program.'))
+        self.parser.add_argument('--quoting',
+                                 default=None,
+                                 choices=[None, 'quote_none', 'quote_all', 'quote_minimal', 'quote_nonnumeric'],
+                                 help='Specify field quoting - generally only used for stdin data.'
+                                      '  The default is to have the program determine quoting.')
+        self.parser.add_argument('--quotechar',
+                                 default='"',
+                                 help='Specify field quoting character - generally only used for '
+                                      'stdin data.  Default is double-quote')
+        self.parser.add_argument('--hasheader',
+                                 dest='hasheader',
+                                 default=None,
+                                 action='store_true',
+                                 help='Indicate that there is a header in the file.')
+        self.parser.add_argument('--hasnoheader',
+                                 dest='hasheader',
+                                 default=None,
+                                 action='store_false',
+                                 help=('Indicate that there is no header in the file.'
+                                       'Occasionally helpful in overriding automatic '
+                                       'csv dialect guessing.'))
+
+        self.parser.add_argument('--long-help',
+                                 default=False,
+                                 action='store_true',
+                                 help='Print more verbose help')
+
+        self.config = self.parser.parse_args()
+
+
+    def validate_user_config(self):
+
+        if self.config.long_help:
+            print(__doc__)
+            sys.exit(0)
+
+        if self.config.infile == '-':  # stdin
+            if not self.config.delimiter:
+                self.parser.error('Please provide delimiter when piping data into program via stdin')
+            if not self.config.quoting:
+                self.config.quoting = 'quote_minimal'
+
+    def extend_config(self):
+        self.config.dialect = csvhelper.get_dialect([self.config.infile],
+                                                    self.config.delimiter,
+                                                    self.config.quoting,
+                                                    self.config.quotechar,
+                                                    self.config.hasheader)
+        self.config.sort_keys = file_sorter.SortKeysConfig(self.config.keys)
+
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/tests/test_gristle_sorter_cmd.py
+++ b/scripts/tests/test_gristle_sorter_cmd.py
@@ -1,0 +1,170 @@
+#zR!/usr/bin/env python
+""" See the file "LICENSE" for the full license governing this code.
+    Copyright 2020 Ken Farmer
+"""
+#adjust pylint for pytest oddities:
+#pylint: disable=missing-docstring
+#pylint: disable=unused-argument
+#pylint: disable=attribute-defined-outside-init
+#pylint: disable=protected-access
+#pylint: disable=no-self-use
+#pylint: disable=empty-docstring
+
+import tempfile
+import shutil
+import csv
+from pprint  import pprint as pp
+import os
+from os.path import dirname
+from os.path import join as pjoin
+
+import envoy
+
+import datagristle.csvhelper as csvhelper
+
+SCRIPT_DIR = dirname(dirname(os.path.realpath((__file__))))
+
+
+
+class TestKeyOptions(object):
+
+    def setup_method(self, method):
+        self.temp_dir = tempfile.mkdtemp(prefix='gristle_sorter_')
+
+    def teardown_method(self, method):
+        shutil.rmtree(self.temp_dir)
+
+    def test_one_key(self):
+        in_fqfn = create_test_file(self.temp_dir)
+        out_fqfn = in_fqfn + '.sorted'
+        cmd = f''' {pjoin(SCRIPT_DIR, 'gristle_sorter')}   \
+                    -i {in_fqfn}
+                    -o {out_fqfn}
+                    -k 0sf
+              '''
+        executor(cmd, expect_success=True)
+        recs = get_file_contents(out_fqfn)
+        assert recs[0][0] == '1'
+        assert recs[1][0] == '2'
+        assert recs[2][0] == '3'
+        assert recs[3][0] == '4'
+
+    def test_two_keys(self):
+        in_fqfn = create_complex_test_file(self.temp_dir)
+        out_fqfn = in_fqfn + '.sorted'
+        cmd = f''' {pjoin(SCRIPT_DIR, 'gristle_sorter')}   \
+                    -i {in_fqfn}
+                    -o {out_fqfn}
+                    -k 0ir 1sf
+              '''
+        executor(cmd, expect_success=True)
+        actual_recs = get_file_contents(out_fqfn)
+        expected_recs = [['4', 'aaa', 'a23'],
+                         ['4', 'aba', 'a23'],
+                         ['4', 'bbb', 'a23'],
+                         ['3', 'aaa', 'b23'],
+                         ['3', 'aaa', 'b23'],
+                         ['1', 'aaa', 'a23']]
+        pp(actual_recs)
+        assert actual_recs == expected_recs
+
+
+
+class TestDuplicateOptions(object):
+
+    def setup_method(self, method):
+        self.temp_dir = tempfile.mkdtemp(prefix='gristle_sorter_')
+
+    def teardown_method(self, method):
+        shutil.rmtree(self.temp_dir)
+
+    def test_nondup(self):
+        in_fqfn = create_test_file(self.temp_dir, duplicate=True)
+        out_fqfn = in_fqfn + '.sorted'
+        cmd = f''' {pjoin(SCRIPT_DIR, 'gristle_sorter')}   \
+                    -i {in_fqfn}
+                    -o {out_fqfn}
+                    -k 0sf
+              '''
+        executor(cmd, expect_success=True)
+        recs = get_file_contents(out_fqfn)
+        assert recs[0][0] == '1'
+        assert recs[1][0] == '2'
+        assert recs[2][0] == '3'
+        assert recs[3][0] == '3'
+        assert recs[4][0] == '4'
+
+
+    def test_dup(self):
+        in_fqfn = create_test_file(self.temp_dir, duplicate=True)
+        out_fqfn = in_fqfn + '.sorted'
+        cmd = f''' {pjoin(SCRIPT_DIR, 'gristle_sorter')}   \
+                    -i {in_fqfn}
+                    -o {out_fqfn}
+                    -k 0sf
+                    -D
+              '''
+        executor(cmd, expect_success=True)
+        recs = get_file_contents(out_fqfn)
+        assert recs[0][0] == '1'
+        assert recs[1][0] == '2'
+        assert recs[2][0] == '3'
+        assert recs[3][0] == '4'
+
+
+
+
+
+def executor(cmd, expect_success=True):
+    runner = envoy.run(cmd)
+    print(runner.std_out)
+    print(runner.std_err)
+    if expect_success:
+        assert runner.status_code == 0
+    else:
+        assert runner.status_code != 0
+
+
+
+def get_file_contents(fqfn):
+    recs = []
+    with open(fqfn, newline='') as buf:
+       reader = csv.reader(buf)
+       recs = list(reader)
+    return recs
+
+
+
+
+def create_test_file(temp_dir, delimiter=',', duplicate=False, header=False):
+    fqfn = pjoin(temp_dir, 'testfile.csv')
+    with open(fqfn, 'w') as f:
+        if header:
+            f.write(delimiter.join(['num', 'alpha', 'alphanumeric']) + '\n')
+        f.write(delimiter.join(['4', 'aaa', 'a23']) + '\n')
+        f.write(delimiter.join(['2', 'bbb', 'a23']) + '\n')
+        f.write(delimiter.join(['1', 'bbb', 'b23']) + '\n')
+        f.write(delimiter.join(['3', 'aaa', 'b23']) + '\n')
+        if duplicate:
+            f.write(delimiter.join(['3', 'aaa', 'b23']) + '\n')
+    return fqfn
+
+
+def create_complex_test_file(temp_dir, delimiter=',', duplicate=False, header=False):
+    """ Has a few more features;
+        - num 4 rows are unique based on num + alpha column
+    - num 1 rows are unique based on num column only
+    - num 3 rows are total duplicates
+    """
+    fqfn = pjoin(temp_dir, 'testfile.csv')
+    with open(fqfn, 'w') as f:
+        if header:
+            f.write(delimiter.join(['num', 'alpha', 'alphanumeric']) + '\n')
+        f.write(delimiter.join(['4', 'aaa', 'a23']) + '\n')
+        f.write(delimiter.join(['4', 'bbb', 'a23']) + '\n')
+        f.write(delimiter.join(['4', 'aba', 'a23']) + '\n')
+        f.write(delimiter.join(['1', 'aaa', 'a23']) + '\n')
+        f.write(delimiter.join(['3', 'aaa', 'b23']) + '\n')
+        f.write(delimiter.join(['3', 'aaa', 'b23']) + '\n')
+    return fqfn
+


### PR DESCRIPTION
The CLI provides most of the features of the unix sort - but is much
more csv aware - and able to properly handle newlines, delimeters and control
characters in the data.

The library will next get used by other programs that require a csv-safe
file sort.