### PR TITLE
Ensure all programs have exit code of 61 for any empty files

### DIFF
--- a/datagristle/file_io.py
+++ b/datagristle/file_io.py
@@ -2,7 +2,7 @@
 """ Contains standard io reading & writing code
 
     See the file "LICENSE" for the full license governing this code.
-    Copyright 2017-2020 Ken Farmer
+    Copyright 2017-2021 Ken Farmer
 """
 import csv
 import errno
@@ -32,17 +32,18 @@ class InputHandler(object):
         self.input_stream = None
         self._open_next_input_file()
 
-    def seek(self, offset):
-        return self.input_stream.seek(offset)
-
-    def tell(self):
-        return self.input_stream.tell()
+#    No longer used - probably because seeking around a csv doesn't work well - because
+#    of newlines
+#    def seek(self, offset):
+#        return self.input_stream.seek(offset)
+#    def tell(self):
+#        return self.input_stream.tell()
 
     def _open_next_input_file(self):
 
         if self.files[0] == '-' and self.files_read == 0:
 
-            if os.isatty(0):  # checks if data was pipped into stdin
+            if os.isatty(0):  # checks if data was piped into stdin
                 sys.exit(errno.ENODATA)
 
             self.input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8', newline='')
@@ -70,9 +71,10 @@ class InputHandler(object):
         """
         while True:
             try:
-                rec = self._read_next_rec()
-                return rec
+                return self._read_next_rec()
             except StopIteration:   # end of file, loop around and get another
+                if self.files[0] == '-' and self.files_read == 1 and self.curr_file_rec_cnt == 1:
+                    sys.exit(errno.ENODATA)
                 self.infile.close()
                 self._open_next_input_file()  # will raise StopIteration if out of files
 

--- a/scripts/gristle_differ
+++ b/scripts/gristle_differ
@@ -159,6 +159,7 @@ Copyright 2011-2021 Ken Farmer
 """
 import copy
 import csv
+import errno
 import logging
 import os
 from  os.path import exists, dirname, basename
@@ -212,8 +213,7 @@ def main():
         config_manager = ConfigManager()
         nconfig, config = config_manager.get_config()
     except EOFError:
-        print('Warning: empty file')
-        return 0
+        sys.exit(errno.ENODATA) #61: empty file
 
     # either file may be empty - but at least one must have data in it.
     assert len(nconfig.infiles) == 2

--- a/scripts/gristle_freaker
+++ b/scripts/gristle_freaker
@@ -147,7 +147,6 @@ def main() -> int:
         config_manager = ConfigManager()
         nconfig = config_manager.get_config()
     except EOFError:
-        print('Warning: empty file')
         sys.exit(errno.ENODATA) # 61: empty file
 
     # Run once for each col_set.  Only col_type of 'each' will have > 1 col_set,

--- a/scripts/gristle_slicer
+++ b/scripts/gristle_slicer
@@ -88,12 +88,13 @@ Examples:
        http://opensource.org/licenses/BSD-3-Clause
     Copyright 2011-2021 Ken Farmer
 """
-import sys
 import csv
+import errno
 import fileinput
 from os.path import basename
 from pprint import pprint as pp
 from signal import signal, SIGPIPE, SIG_DFL
+import sys
 from typing import List, Tuple, Dict, Any, Optional, IO
 
 import datagristle.common as comm
@@ -116,8 +117,7 @@ def main() -> int:
         config_manager = ConfigManager()
         nconfig = config_manager.get_config()
     except EOFError:
-        print('Warning: empty file')
-        return 0
+        return errno.ENODATA
 
     input_handler = file_io.InputHandler(nconfig.infiles,
                                          nconfig.dialect)

--- a/scripts/tests/test_gristle_slicer_cmd.py
+++ b/scripts/tests/test_gristle_slicer_cmd.py
@@ -10,9 +10,10 @@
 #pylint: disable=no-self-use
 #pylint: disable=empty-docstring
 
-import tempfile
+import errno
 import fileinput
 import os
+import tempfile
 
 import envoy
 
@@ -252,7 +253,7 @@ class TestEmptyFile(object):
         r = envoy.run(cmd)
         print(r.std_out)
         print(r.std_err)
-        assert r.status_code == 0
+        assert r.status_code == errno.ENODATA
         out_recs = []
         for rec in fileinput.input(self.out_fqfn):
             out_recs.append(rec)


### PR DESCRIPTION
Whether piped in or read through command line option - the program must
exit with a 61