### PR TITLE
Fix csv dialect overriding bug with quoting

### DIFF
--- a/datagristle/configulator.py
+++ b/datagristle/configulator.py
@@ -230,10 +230,10 @@ class Config(object):
         self.add_standard_metadata('delimiter')
         self.add_standard_metadata('quoting')
         self.add_standard_metadata('quotechar')
-        self.add_standard_metadata('doublequote')
         self.add_standard_metadata('escapechar')
-        self.add_standard_metadata('has_header')
+        self.add_standard_metadata('doublequote')
         self.add_standard_metadata('no_doublequote')
+        self.add_standard_metadata('has_header')
         self.add_standard_metadata('has_no_header')
 
 

--- a/datagristle/csvhelper.py
+++ b/datagristle/csvhelper.py
@@ -8,6 +8,7 @@
 import csv
 import _csv
 import os.path
+from pprint import pprint as pp
 from typing import Optional, List
 
 import datagristle.file_type as file_type
@@ -140,9 +141,9 @@ def override_dialect(dialect: Dialect,
 
     dialect.delimiter = delimiter or dialect.delimiter
 
-    if quoting:
+    if quoting is None:
         dialect.quoting = file_type.get_quote_number(quoting) if quoting else dialect.quoting
-    elif dialect.quoting:
+    elif dialect.quoting is None:
         pass
     else:
         dialect.quoting = file_type.get_quote_number('quote_none')


### PR DESCRIPTION
The problem was that the logic was treating a quoting value of 0
as a None.