### PR TITLE
Fix csv dialect rule and __doc__ hierarchy

### DIFF
--- a/datagristle/configulator.py
+++ b/datagristle/configulator.py
@@ -485,7 +485,11 @@ class Config(object):
             if key == 'dialect':
                 print('    dialect:')
                 for item in [x for x in vars(self.config[key]) if not x.startswith('_')]:
-                    print(f'        {item}:  {getattr(self.config[key], item)}')
+                    if item == 'quoting':
+                        print(f'        {item}:  {getattr(self.config[key], item)}')
+                        print(f'        {item}(translated):  {csvhelper.get_quote_name(getattr(self.config[key], item)) if self.config[key].quoting is not None else None}')
+                    else:
+                        print(f'        {item}:  {getattr(self.config[key], item)}')
             elif key == 'out_dialect':
                 print('    out_dialect:')
                 for item in [x for x in vars(self.config[key]) if not x.startswith('_')]:

--- a/datagristle/csvhelper.py
+++ b/datagristle/csvhelper.py
@@ -109,6 +109,7 @@ def get_dialect(infiles: List[str],
                                          escapechar=escapechar)
 
     if not is_valid_dialect(final_dialect):
+       print_dialect(final_dialect)
        raise ValueError('Error: invalid csv dialect')
     return final_dialect
 
@@ -141,9 +142,9 @@ def override_dialect(dialect: Dialect,
 
     dialect.delimiter = delimiter or dialect.delimiter
 
-    if quoting is None:
-        dialect.quoting = file_type.get_quote_number(quoting) if quoting else dialect.quoting
-    elif dialect.quoting is None:
+    if quoting is not None:
+        dialect.quoting = file_type.get_quote_number(quoting)
+    elif dialect.quoting is not None:
         pass
     else:
         dialect.quoting = file_type.get_quote_number('quote_none')

--- a/scripts/gristle_differ
+++ b/scripts/gristle_differ
@@ -29,11 +29,110 @@ include:
       files
     - populating a batch_id in any or all files
 
-See gristle_differ on the wiki for the most thorough documentation here:
-    https://github.com/kenfar/DataGristle/wiki/gristle_differ
+
+Usage: gristle_differ [options]
+
+    Help Options:
+        -h, --help      Show this help message and exit
+        --long-help     Print more verbose help.
+        -V, --version   Show program's version number and exits.
+
+    Main Options:
+        -i [infiles]    Specifies the two input files.  The first argument is
+                        also referred to as the 'old file', the second as the
+                        'new file'.
+        -k, --key-cols [KEY_COLS [KEY_COLS ...]]
+                        Specifes the columns that constitute a unique row with
+                        a comma-delimited list of field positions using a
+                        0-offset.  If col_names are provided then names can be
+                        used as well as positions.  This is a required option.
+        -c, --compare-cols [COMPARE_COLS [COMPARE_COLS ...]]
+                        Columns to compare - described by their position using
+                        a zero-offset.  If col_names are provided then names
+                        can be used as well as positions.  This option is
+                        mutually exclusive with ignore-cols and key-cols.
+                        If no value is provided then all non-key cols will be compared.
+        --ignore-cols [IGNORE_COLS [IGNORE_COLS ...]]
+                        Columns to ignore - described by their position using a
+                        zero-offset. If col_names are provided then names can be
+                        used as well as positions.  This option is mutually
+                        exclusive with compare-cols and key-cols.  If this column
+                        is provided then all cols except for these identified here and
+                        key-cols will be compared.
+        --col_names [COL_NAMES [COL_NAMES ...]]
+                        Column names - allows other args to reference col names
+                        as well as positions.  If nothing is provided but the files
+                        have headers they will automatically be added to col_names
+                        with a couple of changes: all values are turned to lowercase,
+                        and spaces are replaced with underscores.
+        --variables [VARIABLES [VARIABLES ...]]
+                        Variables to reference with post-delta assignments.
+                        Typical examples are a batch_id, sequence starting num,
+                        or extract timestamp to insert into output recs.  The
+                        format is "<name>:<value>"
+        --already-sorted
+                        Causes program to bypass sorting step.
+        --already-uniq
+                        Causes program to bypass deduping step.
+        --temp-dir TEMP_DIR
+                        Used for temporary files.
+        --config-name CONFIG_NAME
+                        Name of config within XDG dir.  On linux this dir would
+                        be: $HOME/.confg/gristle_differ.  The config is a YAML
+                        file that can contain any of these arguments plus
+                        others used for post-delta record transformations.
+        --config-fn CONFIG_FN
+                        Name of config file.  This allows the user to use any
+                        name and any directory.
+
+    Output Control Options:
+
+        --dry-run       Performs most processing except for final changes.
+        --out-dir OUT_DIR
+                        Where the output files will be written.  Defaults to
+                        the directory of the second file.
+        --verbosity VERBOSITY Controls stdout detail level.  Valid values include:
+                        quiet, normal, high, or debug.
+
+    CSV Dialect Options:
+        -d, --delimiter DELIMITER
+                        Specify a quoted single-column field delimiter. This
+                        will otherwise be determined automatically by the pgm.
+                        Specifying it explicitely is useful when the pgm cannot
+                        accurately determine the csv dialect, especially with
+                        very small files.
+        --escapechar ESCAPECHAR
+                        Specify escaping character. Otherwise, like delimiter,
+                        the program will automatically determine it.
+        --quoting {quote_all,quote_minimal,quite_nonnumeric,quote_none}
+                        Specify field quoting.  Otherwise, like delimiter, the
+                        pgm will automatically determine it.  Valid values are:
+                        quote_none, quote_minimal, quote_nonnumeric, quote_all.
+        --quotechar QUOTECHAR
+                        Specify field quoting character.  Otherwise, like
+                        delimiter the pgm will automatically determine it.
+        --recdelimiter RECDELIMITER
+                        Specify a quoted end-of-record delimiter.
+        --has-header    Indicate that there is a header in the file. This is a
+                        standard datagristle option - but not yet supported
+                        within this pgm.
+        --has-no-header Indicate that there is no header in the file.  This is
+                        a standard datagristle option - but not yet supported
+                        within this pgm.
+
+The config file is useful when the there are many arguments, especially when
+using post-delta transforms.  The program can be referred to a config file in
+either of two ways:
+   - config-fn argument: that references a specific file name
+   - config-name argument: that refers to a file name within the XDG standard
+     directory.
+        - On linux: $HOME/.config/gristle_differ/<name>.yml
+        - On MacOS: $HOME/
+
+
 
 Example 1: Simple Comparison
-    $ gristle_differ file0.dat file1.dat --key-cols 0 2 --ignore-cols 19 22 33
+    $ gristle_differ -i file0.dat file1.dat --key-cols 0 2 --ignore-cols 19 22 33
 
     In this case the two files are each sorted and deduped on columns 0 & 2, and
     then all columns except 19, 22, and 33 are used for the comparison.
@@ -61,95 +160,9 @@ Example 2: Complex Operation
     that will get incremented and used for new rows in the insert, delete and
     chgnew files.
 
-See the wiki page for more examples and information on the operation and config
-file.
+See gristle_differ on the wiki for the most thorough documentation here:
+    https://github.com/kenfar/DataGristle/wiki/gristle_differ
 
-Keyword arguments:
-  -h, --help            Show this help message and exit
-  --long-help           Print more verbose help.
-
-  -i [infiles]          Specifies the two input files.  The first argument is
-                        also referred to as the 'old file', the second as the
-                        'new file'.
-  -k, --key-cols [KEY_COLS [KEY_COLS ...]]
-                        Specifes the columns that constitute a unique row with
-                        a comma-delimited list of field positions using a
-                        0-offset.  If col_names are provided then names can be
-                        used as well as positions.  This is a required option.
-  -c, --compare-cols [COMPARE_COLS [COMPARE_COLS ...]]
-                        Columns to compare - described by their position using
-                        a zero-offset.  If col_names are provided then names
-                        can be used as well as positions.  This option is
-                        mutually exclusive with ignore-cols and key-cols.
-                        If no value is provided then all non-key cols will be compared.
-  --ignore-cols [IGNORE_COLS [IGNORE_COLS ...]]
-                        Columns to ignore - described by their position using a
-                        zero-offset. If col_names are provided then names can be
-                        used as well as positions.  This option is mutually
-                        exclusive with compare-cols and key-cols.  If this column
-                        is provided then all cols except for these identified here and
-                        key-cols will be compared.
-  --col_names [COL_NAMES [COL_NAMES ...]]
-                        Column names - allows other args to reference col names
-                        as well as positions.  If nothing is provided but the files
-                        have headers they will automatically be added to col_names
-                        with a couple of changes: all values are turned to lowercase,
-                        and spaces are replaced with underscores.
-  --variables [VARIABLES [VARIABLES ...]]
-                        Variables to reference with post-delta assignments.
-                        Typical examples are a batch_id, sequence starting num,
-                        or extract timestamp to insert into output recs.  The
-                        format is "<name>:<value>"
-  --already-sorted      Causes program to bypass sorting step.
-  --already-uniq        Causes program to bypass deduping step.
-  --temp-dir TEMP_DIR   Used for temporary files.
-  --out-dir OUT_DIR     Where the output files will be written.  Defaults to
-                        the directory of the second file.
-  --dry-run             Performs most processing except for final changes.
-  --config-name CONFIG_NAME
-                        Name of config within XDG dir.  On linux this dir would
-                        be: $HOME/.confg/gristle_differ.  The config is a YAML
-                        file that can contain any of these arguments plus
-                        others used for post-delta record transformations.
-  --config-fn CONFIG_FN
-                        Name of config file.  This allows the user to use any
-                        name and any directory.
-  -d, --delimiter DELIMITER
-                        Specify a quoted single-column field delimiter. This
-                        will otherwise be determined automatically by the pgm.
-                        Specifying it explicitely is useful when the pgm cannot
-                        accurately determine the csv dialect, especially with
-                        very small files.
-  --escapechar ESCAPECHAR
-                        Specify escaping character. Otherwise, like delimiter,
-                        the program will automatically determine it.
-  --quoting {quote_all,quote_minimal,quite_nonnumeric,quote_none}
-                        Specify field quoting.  Otherwise, like delimiter, the
-                        pgm will automatically determine it.  Valid values are:
-                        quote_none, quote_minimal, quote_nonnumeric, quote_all.
-  --quotechar QUOTECHAR
-                        Specify field quoting character.  Otherwise, like
-                        delimiter the pgm will automatically determine it.
-  --recdelimiter RECDELIMITER
-                        Specify a quoted end-of-record delimiter.
-  --has-header          Indicate that there is a header in the file. This is a
-                        standard datagristle option - but not yet supported
-                        within this pgm.
-  --has-no-header       Indicate that there is no header in the file.  This is
-                        a standard datagristle option - but not yet supported
-                        within this pgm.
-  -V, --version         Show program's version number and exits.
-  --verbosity VERBOSITY Controls stdout detail level.  Valid values include:
-                        quiet, normal, high, or debug.
-
-The config file is useful when the there are many arguments, especially when
-using post-delta transforms.  The program can be referred to a config file in
-either of two ways:
-   - config-fn argument: that references a specific file name
-   - config-name argument: that refers to a file name within the XDG standard
-     directory.
-        - On linux: $HOME/.config/gristle_differ/<name>.yml
-        - On MacOS: $HOME/
 
 This source code is protected by the BSD license.  See the file "LICENSE"
 in the source code root directory for the full language or refer to it here:

--- a/scripts/gristle_viewer
+++ b/scripts/gristle_viewer
@@ -1,42 +1,48 @@
 #!/usr/bin/env python
-""" Displays a single record of a file, pivoted with one field per line, with field names
-    displayed as labels to the left of the field values.  Also allows simple navigation
-    between records.
+"""
+Displays a single record of a file, pivoted with one field per line, with field names
+displayed as labels to the left of the field values.  Also allows simple navigation
+between records.
 
-    arguments & options:
-    -h, --help            show this help message and exit
-    -i, --infiles [INFILES [INFILES ...]]
+Usage: gristle_viewer [options]
+
+    Help Options:
+        -h, --help        show this help message and exit
+        --long-help       Print more verbose help
+        -V, --version     show version number then exit
+
+    Main Options:
+        -i, --infiles [INFILES [INFILES ...]]
                           input filenames or default to for stdin
-    -o, --outfile OUTFILE
+        -o, --outfile OUTFILE
                           output filename or '-' for stdout (the default)
-    -d, --delimiter DELIMITER
-                          csv delimiter
-    -q, --quoting {quote_all,quote_minimal,quote_nonnumeric,quote_none}
-                          csv quoting
-    --quotechar QUOTECHAR
-                          csv quotechar
-    --escapechar ESCAPECHAR
-                          csv escapechar
-    --has-header          csv dialect - indicates header exists
-    -r, --recnum RECNUM
+        -r, --recnum RECNUM
                           Displays this record number based on 0 offset,
                           defaulting to 1
-    -V, --version         show version number then exit
-    --long-help           Print more verbose help
+    CSV Dialect Options:
+        -d, --delimiter DELIMITER
+                            csv delimiter
+        -q, --quoting {quote_all,quote_minimal,quote_nonnumeric,quote_none}
+                            csv quoting
+        --quotechar QUOTECHAR
+                            csv quotechar
+        --escapechar ESCAPECHAR
+                            csv escapechar
+        --has-header        csv dialect - indicates header exists
 
-    Examples:
-       $ gristle_viewer sample.csv -r 3
-                    Presents the third record in the file with one field per line
-                    and field names from the header record as labels in the left
-                    column.
-       $ gristle_viewer sample.csv -r 3  -d '|' -q quote_none
-                    In addition to what was described in the first example this
-                    adds explicit csv dialect overrides.
+Examples:
+    $ gristle_viewer sample.csv -r 3
+        Presents the third record in the file with one field per line
+        and field names from the header record as labels in the left
+        column.
+    $ gristle_viewer sample.csv -r 3  -d '|' -q quote_none
+        In addition to what was described in the first example this
+        adds explicit csv dialect overrides.
 
-    This source code is protected by the BSD license.  See the file "LICENSE"
-    in the source code root directory for the full language or refer to it here:
-       http://opensource.org/licenses/BSD-3-Clause
-    Copyright 2011-2021 Ken Farmer
+This source code is protected by the BSD license.  See the file "LICENSE"
+in the source code root directory for the full language or refer to it here:
+    http://opensource.org/licenses/BSD-3-Clause
+Copyright 2011-2021 Ken Farmer
 """
 
 import errno


### PR DESCRIPTION
The csv dialect rule related to overriding quoting was reversed.  This
change fixes that.

The __doc__ hierarchy ensures that all csv programs organize options
into a hierarchy to make it easier to read.