### PR TITLE
Enable gristle_differ to use the python sort

### DIFF
--- a/datagristle/file_delta.py
+++ b/datagristle/file_delta.py
@@ -114,6 +114,8 @@ class FileDelta(object):
 
         """
         self.dry_run = dry_run
+        self.new_fqfn = new_fqfn
+        self.old_fqfn = old_fqfn
         # validate inputs
         assert isfile(old_fqfn)
         assert isfile(new_fqfn)
@@ -260,8 +262,8 @@ class FileDelta(object):
                     self.new_read_cnt += 1
                     break # good
                 if self.new_rec[key] < last_rec[key]:
-                    print(self.new_rec)
-                    abort('new file is not sorted correctly')
+                    abort('ERROR: new file is not sorted correctly',
+                          f'This refers to file {self.new_fqfn}, and key: {key}, and record: {self.new_rec} and last rec: {last_rec}')
         except StopIteration:
             self.new_rec = None
 
@@ -286,8 +288,8 @@ class FileDelta(object):
                     self.old_read_cnt += 1
                     break # good
                 if self.old_rec[key] < last_rec[key]:
-                    print(self.old_rec)
-                    abort('old file is not sorted correctly')
+                    abort('ERROR: old file is not sorted correctly',
+                          f'This refers to file {self.old_fqfn}, and key: {key}, and record: {self.old_rec} and last rec: {last_rec}')
         except StopIteration:
             self.old_rec = None
 

--- a/datagristle/file_sorter.py
+++ b/datagristle/file_sorter.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import csv
 from dataclasses import dataclass
 import errno
 from operator import itemgetter
@@ -124,20 +123,10 @@ class CSVPythonSorter(object):
         #    raise ValueError('Invalid sort output directory: %s' % out_fqfn)
 
         self.input_handler = file_io.InputHandler([in_fqfn], dialect)
-        #print('------------------------------------------------')
-        #pp(repr(self.input_handler.dialect))
-        #pp(repr(self.input_handler.dialect.__dict__))
-        #pp(repr(dialect.__dict__))
-        #print('------------------------------------------------')
-
 
         self.output_handler = file_io.OutputHandler(out_fqfn,
                                                     self.input_handler.dialect,
                                                     sys.stdout)
-        #print('================================================')
-        #pp(repr(self.output_handler.dialect))
-        #pp(repr(self.output_handler.dialect.__dict__))
-        #print('================================================')
 
     def sort_file(self) -> Dict[str, int]:
         """ Sort input file giving output file
@@ -166,8 +155,6 @@ class CSVPythonSorter(object):
             return 0
 
 
-
-
     def _load_file_and_prepare_data(self) -> None:
         #print('\n ------------------ Read Phase: -------------------------')
         start_time = time.time()
@@ -180,7 +167,6 @@ class CSVPythonSorter(object):
             has_header_adjustment = 0
 
         for rec in self.input_handler:
-            #pp(rec)
             if self.input_handler.dialect.has_header and self.input_handler.rec_cnt == 1:
                 self.header_rec = rec
             else:
@@ -188,7 +174,6 @@ class CSVPythonSorter(object):
                 sort_values = self._get_sort_values(self.sort_key_config.key_fields, rec, primary_order)
                 keys.append((*sort_values, self.input_handler.rec_cnt - 1 - has_header_adjustment))
         #print(f'    duration = {(time.time() - start_time):.4f}')
-
 
 
     def _get_sort_values(self,
@@ -199,9 +184,9 @@ class CSVPythonSorter(object):
         return [transform(rec[key_field.position], key_field, primary_order) for key_field in key_fields]
 
 
-
     def _singlepass_sort(self) -> None:
-
+        """ Sorts the keys in a single direction
+        """
         #print('\n ------------------ Sort Phase: -------------------------')
         start_time = time.time()
         sort_fields = self.sort_key_config.get_sort_fields()
@@ -214,7 +199,8 @@ class CSVPythonSorter(object):
 
 
     def _multipass_sort(self) -> None:
-
+        """ Sorts keys in multiple directions
+        """
         #print('\n ------------------ Multi-Pass Sort Phase: -------------------------')
         start_time = time.time()
 
@@ -282,7 +268,6 @@ def transform(field_value: str,
                 return transformed_field_value * -1
     else:
         return transformed_field_value
-
 
 
 
@@ -388,8 +373,6 @@ class CSVSorter(object):
         stdout, stderr = proc.communicate()
 
         if proc.returncode != 0:
-            print('Invalid sort return code: %s' % proc.returncode)
-            print('delimiter: %s' % self.dialect.delimiter)
             raise IOError('invalid sort return code: %s, %s, %s' % (proc.returncode, stdout, stderr))
 
         return out_fqfn

--- a/scripts/gristle_differ
+++ b/scripts/gristle_differ
@@ -315,13 +315,17 @@ def delta_runner(nconfig,
 
     #--- sort & dedupe the two source files -----
     f0_sorted_uniq_fn, _ = prep_file(nconfig.infiles[0],
-                                     dialect, keys_off0,
-                                     adj_temp_dir, adj_out_dir,
+                                     dialect,
+                                     keys_off0,
+                                     adj_temp_dir,
+                                     adj_out_dir,
                                      nconfig.already_sorted,
                                      nconfig.already_uniq)
     f1_sorted_uniq_fn, _ = prep_file(nconfig.infiles[1],
-                                     dialect, keys_off0,
-                                     adj_temp_dir, adj_out_dir,
+                                     dialect,
+                                     keys_off0,
+                                     adj_temp_dir,
+                                     adj_out_dir,
                                      nconfig.already_sorted,
                                      nconfig.already_uniq)
 
@@ -386,15 +390,30 @@ def prep_file(filename: str,
         - deduped_fn - ends in .uniq
         - final_name - ends in .uniq or .csv (if already-sorted)
     """
+    dups_removed = 0
+
+    # Sort the file if necessary
     if already_sorted:
         sorted_fn = filename
-    else:
+    elif dialect.quoting == csv.QUOTE_NONE:
         sorter = gsorter.CSVSorter(dialect, key_cols, temp_dir, out_dir)
         sorted_fn = sorter.sort_file(filename)
+    else:
+        sorted_fn = filename + '.sorted'
+        sort_key_config = convert_key_offsets_to_sort_key_config(key_cols)
+        sorter = gsorter.CSVPythonSorter(in_fqfn=filename,
+                                         out_fqfn=sorted_fn,
+                                         sort_keys_config=sort_key_config,
+                                         dialect=dialect,
+                                         dedupe=(not already_uniq))
+        sorter.sort_file()
+        sorter.close()
+        dups_removed = sorter.stats['recs_deduped']
+        already_uniq = True
 
+    # Dedupe the file if necessary
     if already_uniq:
         final_name = sorted_fn
-        dups_removed = 0
     else:
         deduper = gdeduper.CSVDeDuper(dialect, key_cols, out_dir)
         final_name, read_cnt, write_cnt = deduper.dedup_file(sorted_fn)
@@ -403,6 +422,13 @@ def prep_file(filename: str,
             os.remove(sorted_fn)
 
     return final_name, dups_removed
+
+
+
+def convert_key_offsets_to_sort_key_config(key_offsets):
+    keys = [f'{x}sf' for x in key_offsets]
+    sort_key_config = gsorter.SortKeysConfig(keys)
+    return sort_key_config
 
 
 


### PR DESCRIPTION
gristle_differ was only using the unix-based sort library in
datagristle, this change enables it to use the python-based sort as
well.

The decision on which sort method to use is based on the dialect - any
non-quoted files will use the unix sort, and any form of quoting will
use the python sort.

The rational is that the python sort is safer, but slower.  The unix
sort should be fine for non-quoted files.