### PR TITLE
Shrink configulator overrides in pgms

### DIFF
--- a/datagristle/configulator.py
+++ b/datagristle/configulator.py
@@ -168,6 +168,15 @@ class Config(object):
         self.nconfig: Optional[NamedTuple] = None
 
 
+    def get_config(self) -> Dict[str, Any]:
+        self.define_user_config()
+        self.process_configs()
+        self.extend_config()
+        if self.nconfig.verbosity == 'debug':
+            self.print_config()
+        return self.nconfig, self.config
+
+
     def add_obsolete_metadata(self,
                               name,
                               short_name,

--- a/datagristle/tests/test_csvhelper.py
+++ b/datagristle/tests/test_csvhelper.py
@@ -79,7 +79,8 @@ class TestGetDialect(object):
                                                   quotechar='!',
                                                   has_header=True,
                                                   doublequote=False,
-                                                  escapechar='\\')
+                                                  escapechar='\\',
+                                                  verbosity='normal')
 
         assert resulting_dialect.delimiter == ','
         assert resulting_dialect.quoting == csv.QUOTE_NONE
@@ -98,7 +99,8 @@ class TestGetDialect(object):
                                                   quotechar=None,
                                                   has_header=None,
                                                   doublequote=None,
-                                                  escapechar=None)
+                                                  escapechar=None,
+                                                  verbosity='normal')
         assert resulting_dialect.delimiter == '|'
         assert resulting_dialect.quoting == csv.QUOTE_ALL
         assert resulting_dialect.quotechar == '"'
@@ -117,7 +119,8 @@ class TestGetDialect(object):
                                                       quotechar=None,
                                                       has_header=None,
                                                       doublequote=None,
-                                                      escapechar=None)
+                                                      escapechar=None,
+                                                      verbosity='normal')
     def test_multiple_files(self):
 
         fqfn1 = generate_test_file('|', csv.QUOTE_ALL, 0)
@@ -129,7 +132,8 @@ class TestGetDialect(object):
                                                   quotechar=None,
                                                   has_header=None,
                                                   doublequote=None,
-                                                  escapechar=None)
+                                                  escapechar=None,
+                                                  verbosity='normal')
         assert resulting_dialect.delimiter == '|'
         assert resulting_dialect.quoting == csv.QUOTE_ALL
         assert resulting_dialect.quotechar == '"'

--- a/scripts/gristle_differ
+++ b/scripts/gristle_differ
@@ -153,22 +153,8 @@ def main():
             - compares files
             - writes counts
     """
-    # collect any config file items then override them with args and assemble the
-    # consolidated info in the 'config' var:
-    desc = ("gristle_differ is used to compare two files and writes the differences to "
-            "five output files named after the inputs with the suffixes: "
-            ".insert, .delete, .same, .chgold, .chgnew.  The program sorts the "
-            "two files based on unique key columns, can ignore certain columns "
-            "for the comparison, and then can perform some simple transformations."
-            "The input files are referred to as old & new, file0 & file1, or f0 & f1 "
-            "this inconsistency reflects the fact that the program may be used "
-            "to compare two historical snapshots of a file (old vs new) or two independent "
-            "files (file0 vs file1)."
-            "\n"
-            "   example:  gristle_differ file0rdat file1.dat --compare-cols '0, 1' --ignore_cols '19,22,33'"
-            "\n\n")
     try:
-        config_manager = ConfigManager()
+        config_manager = ConfigManager(NAME, SHORT_HELP, LONG_HELP)
         nconfig, config = config_manager.get_config()
     except EOFError:
         sys.exit(errno.ENODATA) #61: empty file
@@ -185,7 +171,8 @@ def main():
                                     quotechar=nconfig.quotechar,
                                     has_header=nconfig.has_header,
                                     doublequote=nconfig.doublequote,
-                                    escapechar=nconfig.escapechar)
+                                    escapechar=nconfig.escapechar,
+                                    verbosity=nconfig.verbosity)
 
     config_manager.update_config('col_names', comm.get_best_col_names(config, dialect))
     config = config_manager.config
@@ -378,18 +365,6 @@ def convert_key_offsets_to_sort_key_config(key_offsets):
 
 
 class ConfigManager(configulator.Config):
-
-    def __init__(self):
-        super().__init__(NAME, SHORT_HELP, LONG_HELP)
-
-
-    def get_config(self) -> Dict[str, Any]:
-        self.define_user_config()
-        self.process_configs()
-        self.extend_config()
-        if self.nconfig.verbosity == 'debug':
-            self.print_config()
-        return self.nconfig, self.config
 
 
     def define_user_config(self) -> None:

--- a/scripts/gristle_file_converter
+++ b/scripts/gristle_file_converter
@@ -76,8 +76,8 @@ def main():
 
     """
     try:
-        config_manager = ConfigManager()
-        nconfig = config_manager.get_config()
+        config_manager = ConfigManager(NAME, SHORT_HELP, LONG_HELP)
+        nconfig, _ = config_manager.get_config()
     except EOFError:
         sys.exit(errno.ENODATA) # 61: empty file
 
@@ -106,18 +106,6 @@ def main():
 
 
 class ConfigManager(conf.Config):
-
-    def __init__(self):
-        self.config = None
-        super().__init__(NAME, SHORT_HELP, LONG_HELP)
-
-    def get_config(self) -> Dict[str, Any]:
-        self.define_user_config()
-        self.process_configs()
-        self.extend_config()
-        if self.nconfig.verbosity == 'debug':
-            self.print_config()
-        return self.nconfig
 
 
     def define_user_config(self) -> None:
@@ -166,6 +154,7 @@ class ConfigManager(conf.Config):
 
         self.add_standard_metadata('verbosity')
         self.add_all_config_configs()
+        self.add_all_help_configs()
 
 
 
@@ -181,7 +170,8 @@ class ConfigManager(conf.Config):
                                             self.config['out_quotechar']   or self.nconfig.dialect.quotechar,
                                             self.config['out_has_header']  or self.nconfig.dialect.has_header,
                                             self.config['out_doublequote'] or self.nconfig.dialect.doublequote,
-                                            self.config['out_escapechar']  or self.nconfig.dialect.escapechar)
+                                            self.config['out_escapechar']  or self.nconfig.dialect.escapechar,
+                                            verbosity='normal')
 
         self.update_config('out_dialect', out_dialect)
 

--- a/scripts/gristle_freaker
+++ b/scripts/gristle_freaker
@@ -120,8 +120,8 @@ def main() -> int:
     return_code = 0 # success
 
     try:
-        config_manager = ConfigManager()
-        nconfig = config_manager.get_config()
+        config_manager = ConfigManager(NAME, SHORT_HELP, LONG_HELP)
+        nconfig, _ = config_manager.get_config()
     except EOFError:
         sys.exit(errno.ENODATA) # 61: empty file
 
@@ -395,23 +395,6 @@ class ColumnLengthTracker(object):
 
 
 class ConfigManager(configulator.Config):
-
-    def __init__(self):
-        self.config = None
-        super().__init__(NAME, SHORT_HELP, LONG_HELP)
-
-
-    def get_config(self) -> Dict[str, Any]:
-        """ Raises:
-            - EOFError - if input file is empty when checking for dialect
-        """
-        self.define_user_config()
-        self.define_obsolete_config()
-        self.process_configs()
-        self.extend_config()
-        if self.nconfig.verbosity == 'debug':
-            self.print_config()
-        return self.nconfig
 
 
     def define_obsolete_config(self) -> None:

--- a/scripts/gristle_slicer
+++ b/scripts/gristle_slicer
@@ -96,8 +96,8 @@ SHORT_HELP = helpdoc.get_short_help_from_long(LONG_HELP)
 def main() -> int:
 
     try:
-        config_manager = ConfigManager()
-        nconfig = config_manager.get_config()
+        config_manager = ConfigManager(NAME, SHORT_HELP, LONG_HELP)
+        nconfig, _ = config_manager.get_config()
     except EOFError:
         return errno.ENODATA
 
@@ -130,7 +130,6 @@ def main() -> int:
     output_handler.close()
 
     return 0
-
 
 
 
@@ -257,18 +256,6 @@ def process_rec(rec_number: int,
 
 
 class ConfigManager(conf.Config):
-
-    def __init__(self):
-        super().__init__(NAME, SHORT_HELP, LONG_HELP)
-
-
-    def get_config(self) -> Dict[str, Any]:
-        self.define_user_config()
-        self.process_configs()
-        self.extend_config()
-        if self.nconfig.verbosity == 'debug':
-            self.print_config()
-        return self.nconfig
 
 
     def define_user_config(self) -> None:

--- a/scripts/gristle_sorter
+++ b/scripts/gristle_sorter
@@ -79,8 +79,8 @@ def main() -> int:
     """
     """
     try:
-        config_manager = ConfigManager()
-        nconfig = config_manager.get_config()
+        config_manager = ConfigManager(NAME, SHORT_HELP, LONG_HELP)
+        nconfig, _ = config_manager.get_config()
     except EOFError:
         sys.exit(errno.ENODATA) # 61: empty file
 
@@ -96,20 +96,6 @@ def main() -> int:
 
 
 class ConfigManager(conf.Config):
-
-
-    def __init__(self):
-        self.config = None
-        super().__init__(NAME, SHORT_HELP, LONG_HELP)
-
-
-    def get_config(self) -> Dict[str, Any]:
-        self.define_user_config()
-        self.process_configs()
-        self.extend_config()
-        if self.nconfig.verbosity == 'debug':
-            self.print_config()
-        return self.nconfig
 
 
     def define_user_config(self) -> None:

--- a/scripts/gristle_validator
+++ b/scripts/gristle_validator
@@ -101,8 +101,8 @@ def main() -> int:
     """
 
     try:
-        config_manager = ConfigManager()
-        nconfig = config_manager.get_config()
+        config_manager = ConfigManager(NAME, SHORT_HELP, LONG_HELP)
+        nconfig, _ = config_manager.get_config()
     except EOFError:
         sys.exit(errno.ENODATA) # 61: empty file
 
@@ -463,17 +463,6 @@ class ValidateTheValidator(object):
 
 class ConfigManager(conf.Config):
 
-    def __init__(self):
-        self.config = None
-        super().__init__(NAME, SHORT_HELP, LONG_HELP)
-
-    def get_config(self):
-        self.define_user_config()
-        self.process_configs()
-        self.extend_config()
-        if self.nconfig.verbosity == 'debug':
-            self.print_config()
-        return self.nconfig
 
     def define_user_config(self) -> None:
         """ Defines the user config or metadata.

--- a/scripts/gristle_viewer
+++ b/scripts/gristle_viewer
@@ -68,8 +68,8 @@ def main():
     """
 
     try:
-        config_manager = ConfigManager()
-        nconfig = config_manager.get_config()
+        config_manager = ConfigManager(NAME, SHORT_HELP, LONG_HELP)
+        nconfig, _ = config_manager.get_config()
     except EOFError:
         sys.exit(errno.ENODATA) # 61: empty file
 
@@ -170,18 +170,6 @@ def get_rec(input_handler, recnum: int) -> Optional[List[Any]]:
 
 
 class ConfigManager(conf.Config):
-
-    def __init__(self) -> None:
-        self.config = None
-        super().__init__(NAME, SHORT_HELP, LONG_HELP)
-
-    def get_config(self) -> Dict[str, Any]:
-        self.define_user_config()
-        self.process_configs()
-        self.extend_config()
-        if self.nconfig.verbosity == 'debug':
-            self.print_config()
-        return self.nconfig
 
 
     def define_user_config(self) -> None:

--- a/scripts/tests/test_gristle_freaker.py
+++ b/scripts/tests/test_gristle_freaker.py
@@ -141,8 +141,8 @@ class TestGetArgs(object):
     def test_happy_path(self):
         sys.argv = ['../gristle_freaker', '-i', self.temp_fqfn, '-c', '1']
 
-        config_manager = mod.ConfigManager()
-        nconfig = config_manager.get_config()
+        config_manager = mod.ConfigManager('gristle_freaker', 'short help', 'long help')
+        nconfig, _ = config_manager.get_config()
 
         assert nconfig.columns == [1]
         assert nconfig.outfile == '-'
@@ -159,8 +159,8 @@ class TestGetArgs(object):
 
         sys.argv = ['../gristle_freaker', '-i', self.temp_fqfn, '-c', 'd']
         try:
-            config_manager = mod.ConfigManager()
-            nconfig = config_manager.get_config()
+            config_manager = mod.ConfigManager('gristle_freaker', 'short help', 'long help')
+            nconfig, _ = config_manager.get_config()
         except SystemExit:
             pass
         except Exception as e:
@@ -171,8 +171,8 @@ class TestGetArgs(object):
     def test_check_invalid_maxkeylen(self):
         sys.argv = ['../gristle_freaker', '-i', self.temp_fqfn, '--max-key-len', 'blah']
         try:
-            config_manager = mod.ConfigManager()
-            nconfig = config_manager.get_config()
+            config_manager = mod.ConfigManager('gristle_freaker', 'short help', 'long help')
+            nconfig, _ = config_manager.get_config()
         except SystemExit:
             pass
         except Exception as e:
@@ -184,8 +184,8 @@ class TestGetArgs(object):
         sys.argv = ['../gristle_freaker', '-i', self.temp_fqfn, '-c', '0', '--max-key-len', '50']
 
         try:
-            config_manager = mod.ConfigManager()
-            nconfig = config_manager.get_config()
+            config_manager = mod.ConfigManager('gristle_freaker', 'short help', 'long help')
+            nconfig, _ = config_manager.get_config()
             if nconfig.max_key_len != 50:
                 pytest.fail('max-key-len results did not match expected values: ')
         except SystemExit:


### PR DESCRIPTION
A few simple changes to move about a dozen lins of code from each pgm
into the configulator class to reduce clutter and potential
inconsistencies within each pgm.