### PR TITLE
Get metadata working again

### DIFF
--- a/datagristle/common.py
+++ b/datagristle/common.py
@@ -129,7 +129,8 @@ def abort(summary: str,
     print_solid_line()
     print_text_line(summary)
     print_empty_line()
-    print_text_line(details)
+    if details is not None:
+        print_text_line(details)
     print_empty_line()
     print_text_line('Provide option --help or --long-help for usage information')
     print_empty_line()

--- a/datagristle/metadata.py
+++ b/datagristle/metadata.py
@@ -422,9 +422,9 @@ class FieldTools(simplesql.TableTools):
                                                 name='field_fk2',
                                                 ondelete='RESTRICT'),
                            CheckConstraint('field_len > 0',
-                                           name='field_len_ck1'),
-                           CheckConstraint("field_type in ('string','int','date','time','timestamp','float')",
-                                           name='field_len_ck2'),
+                                           name='field_ck1'),
+                           CheckConstraint("field_type in ('string','int','date','time','timestamp','float', 'unknown')",
+                                           name='field_ck2'),
                            CheckConstraint("( (element_name IS NULL AND field_type IS NOT NULL) \
                                            OR (element_name IS NOT NULL AND field_type IS NULL) ) ",
                                            name='field_ck3'),
@@ -439,8 +439,12 @@ class FieldTools(simplesql.TableTools):
         return self._table
 
 
-    def get_field_id(self, collection_id, field_order=None,
-                     field_name=None, field_type=None, field_len=None,
+    def get_field_id(self,
+                     collection_id,
+                     field_order=None,
+                     field_name=None,
+                     field_type=None,
+                     field_len=None,
                      field_desc=None):
         """Get field_id if one exists, ir not doesn't exist then create it.
            Return final id.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,10 @@
-Flask       == 1.1.2
-Jinja2      == 2.11.3
-ruamel.yaml == 0.16.13
-SQLAlchemy  == 1.4.2
-Werkzeug    == 1.0
 appdirs     == 1.4.4
 cletus      == 1.0.15
 envoy       == 0.0.3
-pytest      == 6.2.2
-validictory == 1.1.2
+Flask       == 1.1.2
+Jinja2      == 2.11.3
 jsonschema  == 3.2.0
+pytest      == 6.2.2
+ruamel.yaml == 0.16.13
+SQLAlchemy  == 1.4.3
+validictory == 1.1.2

--- a/scripts/gristle_md_reporter
+++ b/scripts/gristle_md_reporter
@@ -7,39 +7,40 @@ Currently some of this functionality is redundant with the gristle
 determinator:
    - determinator:  populates metadata and reports on current analysis job
    - md_reporter:   reports on metadata database, is intended for steady
-                    enhancemnts - eventually adding PDF outputs.
+                    enhancements - eventually adding PDF outputs.
 
-usage: gristle_md_reporter [-h] [--long-help] [--report {dd,datadictionary}]
-                           [--schema_id SCHEMA_ID] [--schema_name SCHEMA_NAME]
-                           [--collection_id COLLECTION_ID]
-                           [--collection_name COLLECTION_NAME]
-                           [--field_id FIELD_ID] [--field_name FIELD_NAME]
+usage: gristle_md_reporter [-h] [--long-help]
+                           [--report {dd,datadictionary}]
+                           [--schema-id SCHEMA_ID]
+                           [--schema-name SCHEMA_NAME]
+                           [--collection-id COLLECTION_ID]
+                           [--collection-name COLLECTION_NAME]
+                           [--field-id FIELD_ID]
+                           [--field-name FIELD_NAME]
 
-required arguments:
+Options:
   --report, -r {dd,datadictionary} - Report to be produced:
                 - dd and datadictionary are synonyms
                 - required options:  collection_id
                 - output: a data dictionary for the collection_id
-
-optional arguments (some may be required, depending on report):
   -h, --help            show this help message and exit
   --long-help           Print verbose help and exit.
-  --schema_id SCHEMA_ID, --si SCHEMA_ID
+  --schema-id SCHEMA_ID, --si SCHEMA_ID
                         id of schema
-  --schema_name SCHEMA_NAME, --sn SCHEMA_NAME
-  --collection_id COLLECTION_ID, --ci COLLECTION_ID
-  --collection_name COLLECTION_NAME, --cn COLLECTION_NAME
-  --field_id FIELD_ID, --fi FIELD_ID
-  --field_name FIELD_NAME, --fn FIELD_NAME
+  --schema-name SCHEMA_NAME, --sn SCHEMA_NAME
+  --collection-id COLLECTION_ID, --ci COLLECTION_ID
+  --collection-name COLLECTION_NAME, --cn COLLECTION_NAME
+  --field-id FIELD_ID, --fi FIELD_ID
+  --field-name FIELD_NAME, --fn FIELD_NAME
 
 This source code is protected by the BSD license.  See the file "LICENSE"
 in the source code root directory for the full language or refer to it here:
    http://opensource.org/licenses/BSD-3-Clause
-Copyright 2011,2012,2013,2014,2017 Ken Farmer
+Copyright 2011-2021 Ken Farmer
 """
-import sys
 import argparse
 from signal import signal, SIGPIPE, SIG_DFL
+import sys
 
 from sqlalchemy import (text)
 
@@ -48,6 +49,7 @@ import datagristle.metadata as metadata
 
 #Ignore SIG_PIPE and don't throw exceptions on it... (http://docs.python.org/library/signal.html)
 signal(SIGPIPE, SIG_DFL)
+
 
 
 def main():
@@ -64,7 +66,7 @@ def main():
 
     # eliminate any Nones so they don't confuse _create_where
     # alternatively change _create_where so that it checks for None pk/uks
-    for key in dargs.keys():
+    for key in list(dargs.keys()):
         if dargs[key] is None:
             dargs.pop(key)
     dargs['md'] = my_md
@@ -142,38 +144,7 @@ def rpt_field_analysis(**kwargs):
     """Prints field-level information.
     """
 
-    #-----  format and run query ------------------
-    sql1 = """ SELECT v.field_id, \
-                      v.field_name, \
-                      v.field_type, \
-                      v.field_order, \
-                      v.field_len, \
-                      v.fa_type, \
-                      v.fa_unique_cnt, \
-                      v.fa_known_cnt, \
-                      v.fa_unknown_cnt, \
-                      v.fa_min, \
-                      v.fa_max, \
-                      v.fa_mean, \
-                      v.fa_median, \
-                      v.fa_stddev, \
-                      v.fa_variance, \
-                      v.fa_min_len, \
-                      v.fa_max_len, \
-                      v.fa_mean_len, \
-                      v.fa_case, \
-                      f.field_desc                            \
-               FROM rpt_field_analysis_v v                    \
-                  INNER JOIN field f                          \
-                     ON v.collection_id = f.collection_id     \
-                    AND v.field_id      = f.field_id          \
-               WHERE v.collection_id  = :collection_id        \
-                 AND v.analysis_id    = :analysis_id          \
-               ORDER BY v.field_order                         \
-          """
-
-
-    sql2 = """SELECT c.collection_id,      \
+    sql  = """SELECT c.collection_id,      \
                      ca.analysis_id,       \
                      ca.ca_id,             \
                      f.field_id,           \
@@ -210,21 +181,21 @@ def rpt_field_analysis(**kwargs):
 
 
     if 'field_id' in kwargs:
-        sql2 += " AND field_id = :field_id "
-        select_sql = text(sql2)
+        sql += " AND field_id = :field_id "
+        select_sql = text(sql)
         result = kwargs['md'].engine.execute(select_sql,
                                              collection_id=kwargs['collection_id'],
                                              analysis_id=kwargs['analysis_id'],
                                              field_id=kwargs['field_id'])
     elif 'field_name' in kwargs:
-        sql2 += " AND field_name = :field_name "
-        select_sql = text(sql2)
+        sql += " AND field_name = :field_name "
+        select_sql = text(sql)
         result = kwargs['md'].engine.execute(select_sql,
                                              collection_id=kwargs['collection_id'],
                                              analysis_id=kwargs['analysis_id'],
                                              field_name=kwargs['field_name'])
     else:
-        select_sql = text(sql2)
+        select_sql = text(sql)
         result = kwargs['md'].engine.execute(select_sql,
                                              collection_id=kwargs['collection_id'],
                                              analysis_id=kwargs['analysis_id'])
@@ -321,7 +292,6 @@ def get_analysis_id(md, collection_id):
         with analysis time or name or schema id or name or
         instance id or name.
     """
-
     sql = """ SELECT MAX(anal.analysis_id) as analysis_id  \
               FROM schema                 sch              \
                  INNER JOIN collection    coll             \
@@ -365,15 +335,15 @@ def get_args():
     parser.add_argument('--report', '-r',
                         choices=['dd', 'datadictionary'],
                         help='Report to be produced')
-    parser.add_argument('--schema_id', '--si',
+    parser.add_argument('--schema-id', '--si',
                         help='id of schema')
-    parser.add_argument('--schema_name', '--sn')
-    parser.add_argument('--collection_id', '--ci',
+    parser.add_argument('--schema-name', '--sn')
+    parser.add_argument('--collection-id', '--ci',
                         type=int)
-    parser.add_argument('--collection_name', '--cn')
-    parser.add_argument('--field_id', '--fi',
+    parser.add_argument('--collection-name', '--cn')
+    parser.add_argument('--field-id', '--fi',
                         type=int)
-    parser.add_argument('--field_name', '--fn')
+    parser.add_argument('--field-name', '--fn')
 
     args = parser.parse_args()
 
@@ -383,7 +353,7 @@ def get_args():
     elif not args.report:
         parser.error('Report must be provided')
     elif args.report == 'dd' and args.collection_id is None:
-        parser.error('collection_id must be provided for dd report')
+        parser.error('collection-id must be provided for dd report')
 
     return args
 

--- a/scripts/gristle_metadata
+++ b/scripts/gristle_metadata
@@ -65,7 +65,7 @@ def main():
 
     # eliminate any Nones so they don't confuse _create_where
     # alternatively change _create_where so that it checks for None pk/uks
-    for key in dargs.keys():
+    for key in list(dargs.keys()):
         if dargs[key] is None:
             dargs.pop(key)
 

--- a/scripts/gristle_profiler
+++ b/scripts/gristle_profiler
@@ -215,7 +215,7 @@ def main() -> int:
         sys.exit(errno.ENODATA)  # 61: empty file
 
     if nconfig.metadata:
-        md_man = MetadataManager(nconfig.schemaid, nconfig.collectionid)
+        md_man = MetadataManager(nconfig.schema_id, nconfig.collection_id)
 
     out_writer = OutputWriter(output_filename=nconfig.outfile, output_format=nconfig.outputformat)
 

--- a/web/datagristle_web.py
+++ b/web/datagristle_web.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python
 
 import os, sys
 from pprint import pprint as pp
@@ -7,7 +7,7 @@ from flask import Flask, request, session, g, redirect, url_for, abort, \
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-import gristle.metadata as md
+import datagristle.metadata as md
 ###from sqlite3 import dbapi2 as sqlite3
 from sqlalchemy import (UniqueConstraint, ForeignKeyConstraint, CheckConstraint)
 
@@ -105,7 +105,7 @@ def schema_new():
             try:
                 (rowcnt, rowid) = meta.schema_tools.insert(schema_name=request.form['sn'],
                                                 schema_desc=request.form['sd'])
-            except ValueError, e:
+            except ValueError as e:
                 return render_template("schema_edit.html",
                                         action='new', msg=e,
                                         sn=request.form['sn'],
@@ -124,7 +124,7 @@ def schema_edit(schema_id):
                 (rowcnt, rowid) = meta.schema_tools.update(schema_name=request.form['sn'],
                                                            schema_desc=request.form['sd'],
                                                            schema_id=schema_id)
-           except ValueError, e:
+           except ValueError as e:
                 return render_template("schema_edit.html",
                                        action='edit', msg=e,
                                        sn=request.form['sn'],
@@ -185,7 +185,7 @@ def collection_new(schema_id):
                 rc = meta.collection_tools.setter(schema_id=schema_id,
                                                 collection_name=request.form['cn'],
                                                 collection_desc=request.form['cd'])
-            except ValueError, e:
+            except ValueError as e:
                 return render_template("collection_edit.html", action='new', msg=e,
                                        sid=schema_id, cn=request.form['cn'],
                                        cd=request.form['cd'], cid='')
@@ -205,7 +205,7 @@ def collection_edit(schema_id, coll_id):
                                           collection_id=coll_id,
                                           collection_name=request.form['cn'],
                                           collection_desc=request.form['cd'])
-           except ValueError, e:
+           except ValueError as e:
                return render_template("collection_edit.html", action='edit', msg=e,
                                       cn=request.form['cn'], cd=request.form['cd'],
                                       sid=schema_id, cid=coll_id)
@@ -268,7 +268,7 @@ def field_new(schema_id, coll_id):
                                                   field_type=request.form['ft'],
                                                   field_len=temp_fl,
                                                   element_name=request.form['en'])
-            except ValueError, e:
+            except ValueError as e:
                 return render_template("field_edit.html", sid=schema_id, cid=coll_id, action='new',
                         msg=e, fn=request.form['fn'],fd=request.form['fd'],fo=request.form['fd'],
                                ft=request.form['ft'],fl=request.form['fl'],en=request.form['en'])
@@ -302,7 +302,7 @@ def field_edit(schema_id, coll_id, field_id):
                                                   field_type=request.form['ft'],
                                                   field_len=request.form['fl'],
                                                   element_name=request.form['en'])
-            except ValueError, e:
+            except ValueError as e:
                 app.logger.error('Field experienced an IntegrityError!')
                 msg = 'IntegrityError - data violates rules: %s' % e
                 return render_template("field_edit.html", action='edit', sid=schema_id, cid=coll_id,
@@ -359,8 +359,8 @@ def fv_new(schema_id, coll_id, field_id):
                                                   fv_value=request.form['fv'],
                                                   fv_desc=request.form['fvd'],
                                                   fv_issues=request.form['fvi'])
-            except ValueError, e:
-                print 'fv_new - ValueError'
+            except ValueError as e:
+                print('fv_new - ValueError')
                 return render_template("fv_edit.html", sid=schema_id, cid=coll_id, fid=field_id,
                        action='new', msg=e,
                        fv=request.form['fv'],fvd=request.form['fvd'],fvi=request.form['fvi'])
@@ -384,7 +384,7 @@ def fv_edit(schema_id, coll_id, field_id, fv_value):
                                                   fv_value=fv_value,
                                                   fv_desc=temp_fvd,
                                                   fv_issues=temp_fvi)
-            except ValueError, e:
+            except ValueError as e:
                 app.logger.error('FieldValueexperienced an IntegrityError!')
                 msg = 'IntegrityError - data violates rules: %s' % e
                 return render_template("fv_edit.html", action='edit', sid=schema_id, cid=coll_id,
@@ -448,5 +448,5 @@ def data2form(val):
 
 
 if __name__ == "__main__":
-    #app.run(debug=True)
-    app.run()
+    app.run(debug=True)
+    #app.run()


### PR DESCRIPTION
The metadata code has been mostly ignored for a few years.  These
changes eliminate incompatibilities with python 3.7+, support small
differences in profiler output, and change options to be consistent with
other programs.