### PR TITLE
Establish csv header handling consistency

### DIFF
--- a/scripts/gristle_converter
+++ b/scripts/gristle_converter
@@ -100,11 +100,9 @@ def main():
                                            nconfig.out_dialect)
 
     for rec in input_handler:
-        if input_handler.curr_file_rec_cnt == 1:
-            if (nconfig.dialect.has_header and not nconfig.out_dialect.has_header):
-                continue  # skip input header if output has-no-header
-            elif input_handler.files_read > 1:
-                continue  # skip input header on any files besides the first
+        if nconfig.dialect.has_header and nconfig.out_dialect.has_header:
+            if input_handler.files_read == 1 and input_handler.curr_file_rec_cnt == 1:
+                output_handler.write_rec(input_handler.header)
 
         output_handler.write_rec(rec)
 
@@ -146,6 +144,7 @@ class ConfigManager(conf.Config):
                                  const=True)
         self.add_custom_metadata(name='out_has_no_header',
                                  type=bool,
+                                 dest='out_has_header',
                                  action='store_const',
                                  const=False)
         self.add_custom_metadata(name='out_escapechar',
@@ -176,19 +175,25 @@ class ConfigManager(conf.Config):
         """
         self.generate_csv_dialect_config()
 
+        def coalesce(key):
+            if self.config.get(f'out_{key}') is not None:
+                return self.config.get(f'out_{key}')
+            else:
+                return getattr(self.nconfig.dialect, key)
+
         # pylint: disable=no-member
-        out_dialect = csvhelper.get_dialect('-',  # type: ignore
-            self.config['out_delimiter']   or self.nconfig.dialect.delimiter,  # type: ignore
-            self.config['out_quoting'] or csvhelper.get_quote_name(self.nconfig.dialect.quoting), # type: ignore
-            self.config['out_quotechar']   or self.nconfig.dialect.quotechar, # type: ignore
-            self.config['out_has_header']  or self.nconfig.dialect.has_header, # type: ignore
-            self.config['out_doublequote'] or self.nconfig.dialect.doublequote, # type: ignore
-            self.config['out_escapechar']  or self.nconfig.dialect.escapechar, # type: ignore
-            self.config['out_skipinitialspace']
-                or self.nconfig.dialect.skipinitialspace, verbosity='normal') # type: ignore
+        out_dialect = csvhelper.get_dialect(infiles=['-'],
+            delimiter=coalesce('delimiter'),
+            quoting=self.config['out_quoting']
+                or csvhelper.get_quote_name(self.nconfig.dialect.quoting), # type: ignore
+            quotechar=coalesce('quotechar'),
+            has_header=coalesce('has_header'),
+            doublequote=coalesce('doublequote'),
+            escapechar=coalesce('escapechar'),
+            skipinitialspace=coalesce('skipinitialspace'),
+            verbosity='normal') # type: ignore
 
         self.update_config('out_dialect', out_dialect)
-
 
 
 if __name__ == '__main__':

--- a/scripts/gristle_freaker
+++ b/scripts/gristle_freaker
@@ -151,9 +151,8 @@ def main() -> int:
                                        nconfig.sort_col,
                                        nconfig.max_key_len)
         colset_freaker.create_freq_from_column_set(nconfig.col_set)
-        total_read_cnt += colset_freaker.read_cnt
+        total_read_cnt += colset_freaker.input_handler.rec_cnt
 
-        #colset_freaker.write_output(nconfig.outfile,
         colset_freaker.write_output(colset_freaker.output_handler,
                                     nconfig.write_limit,
                                     nconfig.col_set[0])
@@ -203,7 +202,6 @@ class ColSetFreaker(object):
         self.field_freq: Dict[Any, Any] = {}
         self.sort_freq: List[Any] = None
         self.truncated: bool = None
-        self.read_cnt = 0
 
 
     def create_freq_from_column_set(self, col_set: List[int]) -> None:
@@ -233,18 +231,14 @@ class ColSetFreaker(object):
                 - truncated  - True/False boolean that indicates if the dict was truncated
                 Tested via test-harness
         """
-        self.read_cnt = 0
         freq_cnt = 0
         self.field_freq = {}
         self.truncated = False
 
         def process_rec(record: List[str]) -> None:
             nonlocal freq_cnt
-            self.read_cnt += 1
-            if self.read_cnt == 1 and self.input_handler.dialect.has_header:
-                return
             if self.sampling_method == 'interval':
-                if self.read_cnt % self.sampling_rate != 0:
+                if (self.input_handler.rec_cnt+1) % self.sampling_rate != 0:
                     return
             key = self._create_key(record, columns)
             if key:

--- a/scripts/gristle_slicer
+++ b/scripts/gristle_slicer
@@ -103,7 +103,8 @@ def main() -> int:
         return errno.ENODATA
 
     input_handler = file_io.InputHandler(nconfig.infiles,
-                                         nconfig.dialect)
+                                         nconfig.dialect,
+                                         return_header=True)
 
     (incl_rec_slicer,
      excl_rec_slicer,

--- a/scripts/gristle_viewer
+++ b/scripts/gristle_viewer
@@ -80,7 +80,8 @@ def main():
     recnum = nconfig.recnum
     while True:
         input_handler = file_io.InputHandler(nconfig.infiles,
-                                             nconfig.dialect)
+                                             nconfig.dialect,
+                                             return_header=True)
         if not field_names:
             field_names = get_field_names(nconfig.infiles, input_handler.dialect)
         rec = get_rec(input_handler, recnum)


### PR DESCRIPTION
This change ensures that the input header:
1. Can be referred to as row=0 when necessary (ex: gristle_slicer, gristle_viewer)
2. But is normally withheld from the program (ex: gristle_freaker, gristle_sorter, etc)