### PR TITLE
Ready the code for release 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 
+# V0.2.2 - 2021-05
+   * Improvement: the field-names from headers can now be used instead of column offsets
+     for gristle_sorter, gristle_freaker, gristle_profiler, and gristle_slicer.
+   * Improvement: The use of the header now follows four simple rules:
+      * It can be referred to as row 0 when it makes sense - like with gristle_slicer
+        & gristle_viewer.
+      * It will be passed through when it makes sense - like with gristle_sorter.
+      * It will be used to translate field names to offsets for configuration.
+      * But will otherwise be ignored.
+   * Bug Fix: gristle_freaker was failing with 0-length files when using col-type=each
+   * Bug Fix: gristle_sorter was failing with some multi-directional sorts
+  
 # V0.2.1 - 2021-04
    * Improvement: added gristle_sorter as a script to install in the system so that it is
      available to users.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,23 @@
+V0.2.2 - 2021-05
+================
+
+-  Improvement: the field-names from headers can now be used instead of
+   column offsets for gristle_sorter, gristle_freaker, gristle_profiler,
+   and gristle_slicer.
+-  Improvement: The use of the header now follows four simple rules:
+
+   -  It can be referred to as row 0 when it makes sense - like with
+      gristle_slicer & gristle_viewer.
+   -  It will be passed through when it makes sense - like with
+      gristle_sorter.
+   -  It will be used to translate field names to offsets for
+      configuration.
+   -  But will otherwise be ignored.
+
+-  Bug Fix: gristle_freaker was failing with 0-length files when using
+   col-type=each
+-  Bug Fix: gristle_sorter was failing with some multi-directional sorts
+
 V0.2.1 - 2021-04
 ================
 

--- a/datagristle/_version.py
+++ b/datagristle/_version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/datagristle/file_sorter.py
+++ b/datagristle/file_sorter.py
@@ -223,7 +223,7 @@ class CSVPythonSorter(object):
         try:
             sort_values = [transform(rec[key_field.position], key_field, primary_order) for key_field in key_fields]
         except IndexError:
-            comm.abort('Error: key references columns that does not exist in record', f'{rec=}')
+            comm.abort('Error: key references columns that does not exist in record', f'rec={rec}')
         return sort_values
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 appdirs     == 1.4.4
 cletus      == 1.0.15
+colorama    == 0.4.3
 envoy       == 0.0.3
 Flask       == 1.1.2
 Jinja2      == 2.11.3


### PR DESCRIPTION
This includes a _version bump and CHANGELOG update, but also:
* addition of a module used in testing
* elimination of a diagnostic use of fstrings that is one of the few
reasons it doesn't work on python 3.7 any more.