### PR TITLE
Fix config file & env boolean logic

### DIFF
--- a/datagristle/tests/test_configulator.py
+++ b/datagristle/tests/test_configulator.py
@@ -8,6 +8,8 @@ from pprint import pprint as pp
 import shutil
 import tempfile
 
+import pytest
+
 import datagristle.configulator as mod
 
 
@@ -35,16 +37,19 @@ class TestEnvironmentalArgs(object):
                                    arg_type='option',
                                    default=None,
                                    help=SHORT_HELP)
+        config.add_standard_metadata('has_header')
+        config.add_standard_metadata('has_no_header')
+
         self._app_metadata = config._app_metadata
         pp(self._app_metadata)
+
 
     def teardown_method(self, method):
         try:
             os.environ.pop(f'{GRISTLE_APP_NAME}_delimiter')
-        except KeyError:
-            pass
-        try:
             os.environ.pop(f'{GRISTLE_APP_NAME}_counter')
+            os.environ.pop(f'{GRISTLE_APP_NAME}_has_header')
+            os.environ.pop(f'{GRISTLE_APP_NAME}_has_no_header')
         except KeyError:
             pass
 
@@ -80,6 +85,29 @@ class TestEnvironmentalArgs(object):
         assert env_config['counter'] == 999
 
 
+    def test_boolean_has_header(self):
+
+        # export arg into environment:
+        os.environ[f'{GRISTLE_APP_NAME}_has_header'] = 'true'
+
+        # now confirm environment args produce an good results:
+        env_args = mod._EnvironmentalArgs(GRISTLE_APP_NAME, self._app_metadata)
+        env_config = env_args._get_gristle_app_args()
+        pp(env_config)
+        assert env_config['has_header'] is True
+
+
+    def test_reverse_boolean_has_no_header(self):
+
+        # export arg into environment:
+        os.environ[f'{GRISTLE_APP_NAME}_has_no_header'] = 'true'
+
+        # now confirm environment args produce an good results:
+        env_args = mod._EnvironmentalArgs(GRISTLE_APP_NAME, self._app_metadata)
+        env_config = env_args._get_gristle_app_args()
+        assert env_config['has_header'] is False
+
+
 
 
 class TestFileArgs(object):
@@ -100,7 +128,14 @@ class TestFileArgs(object):
                                    arg_type='option',
                                    default=None,
                                    help=SHORT_HELP)
+        config.add_custom_metadata(name='assignments',
+                                   type=list,
+                                   arg_type='option',
+                                   default=None,
+                                   help=SHORT_HELP)
         config.add_standard_metadata('config_fn')
+        config.add_standard_metadata('has_header')
+        config.add_standard_metadata('has_no_header')
         self._app_metadata = config._app_metadata
         pp(self._app_metadata)
 
@@ -112,9 +147,7 @@ class TestFileArgs(object):
 
         config_dict_to_write = {}
         self.config_fqfn = create_config_file(self.temp_dir, config_dict_to_write)
-
-
-        file_args = mod._FileArgs(self.config_fqfn)
+        file_args = mod._FileArgs(self.config_fqfn, self._app_metadata)
         assert file_args.file_gristle_app_args == {}
 
 
@@ -124,7 +157,7 @@ class TestFileArgs(object):
                                 'counter': 999}
         self.config_fqfn = create_config_file(self.temp_dir, config_dict_to_write)
         self._app_metadata['config-fn'] = self.config_fqfn
-        file_args = mod._FileArgs(self.config_fqfn)
+        file_args = mod._FileArgs(self.config_fqfn, self._app_metadata)
         assert file_args.file_gristle_app_args == config_dict_to_write
 
 
@@ -141,11 +174,118 @@ class TestFileArgs(object):
                                 }
         self.config_fqfn = create_config_file(self.temp_dir, config_dict_to_write)
         self._app_metadata['config-fn'] = self.config_fqfn
-        file_args = mod._FileArgs(self.config_fqfn)
+        file_args = mod._FileArgs(self.config_fqfn, self._app_metadata)
         assert file_args.file_gristle_app_args == config_dict_to_write
 
+
+    def test_boolean_has_header(self):
+
+        config_dict_to_write = {'has_header': True}
+        self.config_fqfn = create_config_file(self.temp_dir, config_dict_to_write)
+        self._app_metadata['config-fn'] = self.config_fqfn
+        file_args = mod._FileArgs(self.config_fqfn, self._app_metadata)
+        assert file_args.file_gristle_app_args == config_dict_to_write
+
+
+    def test_reverse_boolean_has_header(self):
+
+        config_dict_to_write = {'has_no_header': True}
+        self.config_fqfn = create_config_file(self.temp_dir, config_dict_to_write)
+        self._app_metadata['config-fn'] = self.config_fqfn
+        file_args = mod._FileArgs(self.config_fqfn, self._app_metadata)
+        #assert file_args.file_gristle_app_args == {'has_no_header': True}
+        assert file_args.file_gristle_app_args == {'has_header': False}
+
+
+# need to test consolidation!
+
+# need to test cli
 
 def create_config_file(temp_dir, config_dict):
     with open(pjoin(temp_dir, 'config_file.json'), 'w') as outbuf:
         json.dump(config_dict, outbuf)
     return pjoin(temp_dir, 'config_file.json')
+
+
+
+
+class TestBinaryArgFixer(object):
+
+    def setup_method(self, method):
+
+        self.temp_dir = tempfile.mkdtemp(prefix='gristle_test_')
+
+        # setup app_config:
+        self.config = mod.Config(PGM_NAME, SHORT_HELP, LONG_HELP)
+        self.config.add_custom_metadata(name='delimiter',
+                                   type=str,
+                                   arg_type='option',
+                                   default=None,
+                                   help=SHORT_HELP)
+        self.config.add_custom_metadata(name='counter',
+                                   type=int,
+                                   arg_type='option',
+                                   default=None,
+                                   help=SHORT_HELP)
+        self.config.add_standard_metadata('config_fn')
+        self.config.add_standard_metadata('has_header')
+        self.config.add_standard_metadata('has_no_header')
+        self._app_metadata = self.config._app_metadata
+        pp(self._app_metadata)
+
+    def teardown_method(self, method):
+        shutil.rmtree(self.temp_dir)
+
+
+    def test_empty_args(self):
+
+        test_config = {}
+        assert mod.binary_arg_fixer(self._app_metadata, test_config) == {}
+
+
+    def test_bool_true_args(self):
+
+        test_config = {}
+        test_config['has_header'] = 'true'
+        resulting_args = mod.binary_arg_fixer(self._app_metadata, test_config)
+        assert resulting_args['has_header'] == True
+
+        test_config['has_header'] = 'True'
+        resulting_args = mod.binary_arg_fixer(self._app_metadata, test_config)
+        assert resulting_args['has_header'] == True
+
+        test_config['has_header'] = 'TRUE'
+        resulting_args = mod.binary_arg_fixer(self._app_metadata, test_config)
+        assert resulting_args['has_header'] == True
+
+        test_config['has_header'] = '1'
+        resulting_args = mod.binary_arg_fixer(self._app_metadata, test_config)
+        assert resulting_args['has_header'] == True
+
+        test_config['has_header'] = 't'
+        resulting_args = mod.binary_arg_fixer(self._app_metadata, test_config)
+        assert resulting_args['has_header'] == True
+
+        test_config['has_header'] = 'T'
+        resulting_args = mod.binary_arg_fixer(self._app_metadata, test_config)
+        assert resulting_args['has_header'] == True
+
+        test_config['has_header'] = ''
+        resulting_args = mod.binary_arg_fixer(self._app_metadata, test_config)
+        assert resulting_args['has_header'] == True
+
+
+    def test_bool_false_args(self):
+
+        test_config = {}
+        test_config['has_header'] = 'false'
+        with pytest.raises(SystemExit):
+            resulting_args = mod.binary_arg_fixer(self._app_metadata, test_config)
+
+        test_config = {}
+        test_config['has_header'] = '0'
+        with pytest.raises(SystemExit):
+            resulting_args = mod.binary_arg_fixer(self._app_metadata, test_config)
+
+
+

--- a/examples/gristle_converter/example-01.yml
+++ b/examples/gristle_converter/example-01.yml
@@ -7,6 +7,6 @@ delimiter: ','
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_converter/example-02.yml
+++ b/examples/gristle_converter/example-02.yml
@@ -7,6 +7,6 @@ delimiter: ','
 has_header: true
 skipinitialspace: true
 
-doublequote: null
 escapechar: null
-quotechar: null
+#doublequote: null      # bools can only be set to true
+#quotechar: null        # bools can only be set to true

--- a/examples/gristle_converter/example-03.yml
+++ b/examples/gristle_converter/example-03.yml
@@ -5,9 +5,9 @@ outfile: /tmp/example-03_actualout.csv
 verbosity: debug
 
 delimiter: null
-doublequote: null
 escapechar: null
-has_header: null
 quotechar: null
 quoting: null
-skipinitialspace: null
+#has_header: null               # bools can only be set to true
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_converter/example-04.yml
+++ b/examples/gristle_converter/example-04.yml
@@ -9,4 +9,4 @@ has_header: true
 
 escapechar: null
 quotechar: null
-skipinitialspace: null
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_converter/example-05.yml
+++ b/examples/gristle_converter/example-05.yml
@@ -7,6 +7,6 @@ delimiter: ','
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_converter/example-06.yml
+++ b/examples/gristle_converter/example-06.yml
@@ -7,6 +7,6 @@ delimiter: ','
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_converter/example-07.yml
+++ b/examples/gristle_converter/example-07.yml
@@ -7,6 +7,6 @@ delimiter: ','
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_converter/example-21.yml
+++ b/examples/gristle_converter/example-21.yml
@@ -6,12 +6,12 @@ quoting: quote_none
 delimiter: ','
 escapechar: \
 has_header: true
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true
 
 out_quoting: quote_all
 out_delimiter: '|'
-out_has_header: false
+out_has_no_header: true
 out_doublequote: true
 out_quotechar: '"'

--- a/examples/gristle_differ/example-01.yml
+++ b/examples/gristle_differ/example-01.yml
@@ -1,7 +1,7 @@
 infiles: [example-01_dialect-qnone_empty_input2.csv,
           example-01_dialect-qnone_input1.csv]
-out-dir: /tmp/example-01_actual_output_files
-key-cols: [2]
+out_dir: /tmp/example-01_actual_output_files
+key_cols: [2]
 verbosity: debug
 
 quoting: quote_none
@@ -10,5 +10,5 @@ escapechar: \
 has_header: true
 
 quotechar: null
-doublequote: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_differ/example-01_dialect-qnone_input1.csv.insert
+++ b/examples/gristle_differ/example-01_dialect-qnone_input1.csv.insert
@@ -1,0 +1,5 @@
+2,aaa,embedded\
+newline
+4,ddd,embedded\,delimiter
+1,bbb,simple1
+3,ccc,simple2

--- a/examples/gristle_differ/example-02.yml
+++ b/examples/gristle_differ/example-02.yml
@@ -1,7 +1,7 @@
 infiles: [example-02_dialect-qnone-skipinitialspace_input1.csv,
           example-02_dialect-qnone-skipinitialspace_empty_input2.csv]
-out-dir: '/tmp/example-02_actual_output_files'
-key-cols: [2]
+out_dir: '/tmp/example-02_actual_output_files'
+key_cols: [2]
 verbosity: debug
 
 quoting: quote_none
@@ -10,5 +10,5 @@ has_header: true
 skipinitialspace: true
 
 quotechar: null
-doublequote: null
 escapechar: null
+#doublequote: null      # bools can only be set to true

--- a/examples/gristle_differ/example-03.yml
+++ b/examples/gristle_differ/example-03.yml
@@ -2,15 +2,15 @@
 #
 infiles: [example-03_dialect-qnone-autodetect_input1.csv,
           example-03_dialect-qnone-autodetect_empty_input2.csv]
-out-dir: /tmp/example-03_actual_output_files
-key-cols: [2]
+out_dir: /tmp/example-03_actual_output_files
+key_cols: [2]
 verbosity: debug
 
-delimiter: null   # should figure out it's ','
-quoting: null     # should figure out it's quote_none
-has_header: null  # should figure out it's true
+delimiter: null                 # should figure out it's ','
+quoting: null                   # should figure out it's quote_none
+#has_header: null               # should figure out it's true, but not setting since bools can only be set to true
 
-doublequote: null
 escapechar: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_differ/example-04.yml
+++ b/examples/gristle_differ/example-04.yml
@@ -1,7 +1,7 @@
 infiles: [example-04_dialect-qall-doublequote_input1.csv,
           example-04_dialect-qall-doublequote_empty_input2.csv]
-out-dir: /tmp/example-04_actual_output_files
-key-cols: [2]
+out_dir: /tmp/example-04_actual_output_files
+key_cols: [2]
 verbosity: debug
 
 quoting: quote_all
@@ -11,4 +11,4 @@ has_header: true
 
 escapechar: null
 quotechar: null
-skipinitialspace: null
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_differ/example-05.yml
+++ b/examples/gristle_differ/example-05.yml
@@ -1,7 +1,7 @@
 infiles: [example-05_dialect-qall-escape_input1.csv,
           example-05_dialect-qall-escape_empty_input2.csv]
-out-dir: /tmp/example-05_actual_output_files
-key-cols: [2]
+out_dir: /tmp/example-05_actual_output_files
+key_cols: [2]
 verbosity: debug
 
 quoting: quote_all
@@ -10,5 +10,5 @@ escapechar: \
 has_header: true
 
 quotechar: null
-doublequote: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_differ/example-06.yml
+++ b/examples/gristle_differ/example-06.yml
@@ -1,7 +1,7 @@
 infiles: [example-06_dialect-qmin_input1.csv,
           example-06_dialect-qmin_empty_input2.csv]
-out-dir: /tmp/example-06_actual_output_files
-key-cols: [2]
+out_dir: /tmp/example-06_actual_output_files
+key_cols: [2]
 verbosity: debug
 
 quoting: quote_minimal
@@ -10,5 +10,5 @@ escapechar: \
 has_header: true
 
 quotechar: null
-doublequote: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_differ/example-07.yml
+++ b/examples/gristle_differ/example-07.yml
@@ -1,7 +1,7 @@
 infiles: [example-07_dialect-qnonnum_input1.csv,
           example-07_dialect-qnonnum_empty_input2.csv]
-out-dir: /tmp/example-07_actual_output_files
-key-cols: [2]
+out_dir: /tmp/example-07_actual_output_files
+key_cols: [2]
 verbosity: debug
 
 quoting: quote_all
@@ -10,5 +10,5 @@ escapechar: \
 has_header: true
 
 quotechar: null
-doublequote: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_differ/example-08.yml
+++ b/examples/gristle_differ/example-08.yml
@@ -1,7 +1,7 @@
 infiles: [example-08_dialect-qnone_input1.csv,
           example-08_dialect-qnone_empty_input2.csv]
-out-dir: /tmp/example-08_actual_output_files
-key-cols: [2]
+out_dir: /tmp/example-08_actual_output_files
+key_cols: [2]
 verbosity: debug
 
 quoting: quote_all
@@ -10,5 +10,5 @@ escapechar: \
 has_header: true
 
 quotechar: null
-doublequote: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_differ/example-09.yml
+++ b/examples/gristle_differ/example-09.yml
@@ -1,7 +1,7 @@
 infiles: [example-09_dialect-qnone_input1.csv,
           example-09_dialect-qnone_empty_input2.csv]
-out-dir: /tmp/example-09_actual_output_files
-key-cols: [2]
+out_dir: /tmp/example-09_actual_output_files
+key_cols: [2]
 verbosity: debug
 
 quoting: quote_all
@@ -10,5 +10,5 @@ escapechar: \
 has_header: true
 
 quotechar: null
-doublequote: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_differ/example-21.yml
+++ b/examples/gristle_differ/example-21.yml
@@ -6,7 +6,7 @@
 #
 infiles: [example-21_sensor_old_input1.csv,
           example-21_sensor_new_input2.csv]
-out-dir: /tmp/example-21_actual_output_files
+out_dir: /tmp/example-21_actual_output_files
 temp_dir: null
 
 # Ordered list of columns that get assigned positions starting at 0.  This allows us to refer
@@ -14,14 +14,14 @@ temp_dir: null
 # by position instead.
 col_names: [org,sensor_id,site,sensor_ip,sensor_brand,sensor_ver,sensor_type,update_ts,comments]
 
-key-cols: [org, sensor_id]  #
+key_cols: [org, sensor_id]  #
 ignore_cols: [comments]     # won't be on new file - just our debugging comments
 compare_cols: []            #
 
 variables: []
 
-already_sorted: false
-already_uniq: false
+#already_sorted: true       # will default to false
+#already_uniq: true         # will default to false
 
 # Here's where the output records are transformed slightly.  Note that all fields must be provided, even if null.
 assignments:  []
@@ -32,5 +32,5 @@ delimiter: '|'
 has_header: true
 quotechar: null
 escapechar: null
-doublequote: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_differ/example-22.yml
+++ b/examples/gristle_differ/example-22.yml
@@ -23,7 +23,7 @@
 #
 infiles: [example-22_sensor_old_input1.csv,
           example-22_sensor_new_input2.csv]
-out-dir: /tmp/example-22_actual_output_files
+out_dir: /tmp/example-22_actual_output_files
 temp_dir: null
 
 
@@ -37,7 +37,7 @@ col_names: [org,sensor_id,site,sensor_ip,sensor_brand,sensor_ver,sensor_type,upd
             start_ts,        # part of the unique key, assigned to all but same files
             stop_ts ]        # part of the unique key, assigned to delete & chgold files
 
-key-cols: [org, sensor_id]
+key_cols: [org, sensor_id]
 ignore_cols: [comments,      # won't be on new file - just our debugging comments
               start_ts,      # won't be on new file
               stop_ts,       # won't be on new file
@@ -51,8 +51,8 @@ variables: ['var_pkey:89',
             'var_batch_id:101',
             'var_extract_ts:2021-04-02T18:00:00']
 
-already_sorted: false
-already_uniq: false
+#already_sorted: true        # will default to false
+#already_uniq: true          # will default to false
 
 # Here's where the output records are transformed slightly.  Note that all fields must be provided, even if null.
 assignments:  [
@@ -85,5 +85,5 @@ delimiter: '|'
 has_header: true
 quotechar: null
 escapechar: null
-doublequote: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_differ/example-23.yml
+++ b/examples/gristle_differ/example-23.yml
@@ -14,11 +14,11 @@
 infiles: [example-23_sensor_old_input1.csv,
           example-23_sensor_new_input2.csv]
 
-out-dir: /tmp/example-23_actual_output_files
+out_dir: /tmp/example-23_actual_output_files
 temp_dir: null
 
 col_names: []
-key-cols: [org, sensor_id]
+key_cols: [org, sensor_id]
 
 # Lets compare a subset of columns - ignoring those we leave out (all those at the bottom of the 
 # col_names list).  
@@ -34,7 +34,7 @@ variables: []
 
 # Files have headers and so are not eligible for skipping sorting, but they are already verified
 # to be unique so we'll skip this step to improve performance.
-already_sorted: false
+#already_sorted: true           # will default to false
 already_uniq: true
 
 # Assignments aren't needed for a simple csv comparison
@@ -47,5 +47,5 @@ delimiter: '|'
 has_header: true
 quotechar: null
 escapechar: null
-doublequote: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_differ/example-24.yml
+++ b/examples/gristle_differ/example-24.yml
@@ -10,11 +10,11 @@
 
 infiles: [example-24_sensor_old_input1.csv,
           example-24_sensor_new_input2.csv]
-out-dir: /tmp/example-24_actual_output_files
+out_dir: /tmp/example-24_actual_output_files
 temp_dir: null
 
 col_names: []
-key-cols: [0, 1]
+key_cols: [0, 1]
 
 # Lets compare a subset of columns - ignoring those we leave out (all those at the bottom of the 
 # col_names list).  
@@ -24,8 +24,8 @@ compare_cols: [2, 3, 4, 5, 6]
 # Variables aren't needed for a simple csv comparison
 variables: []
 
-already_sorted: false
-already_uniq: false
+#already_sorted: true           # will default to false
+#already_uniq: true             # will default to false
 
 # Assignments aren't needed for a simple csv comparison
 assignments:  []
@@ -34,8 +34,8 @@ verbosity: debug
 
 quoting: quote_none
 delimiter: '|'
-has_header: false
+has_no_header: true
 quotechar: null
 escapechar: null
-doublequote: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_dir_merger/example-01.yml
+++ b/examples/gristle_dir_merger/example-01.yml
@@ -5,7 +5,7 @@ match_on: name_and_md5
 on_full_match: keep_dest
 on_partial_match: keep_newest
 
-dry_run: false
+#dry_run: true                  # will default to false
 recursive: false
 ignore_errors: false
 

--- a/examples/gristle_dir_merger/example-02.yml
+++ b/examples/gristle_dir_merger/example-02.yml
@@ -5,8 +5,8 @@ match_on: name_and_md5
 on_full_match: keep_dest
 on_partial_match: keep_biggest
 
-dry_run: false
+#dry_run: true                  # will default to false
 recursive: true
-ignore_errors: false
+#ignore_errors: true            # will default to false
 
 verbosity: debug

--- a/examples/gristle_freaker/example-01.yml
+++ b/examples/gristle_freaker/example-01.yml
@@ -9,5 +9,5 @@ has_header: true
 verbosity: normal
 
 quotechar: null
-doublequote: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_freaker/example-02.yml
+++ b/examples/gristle_freaker/example-02.yml
@@ -10,4 +10,4 @@ verbosity: debug
 
 escapechar: null
 quotechar: null
-doublequote: null
+#doublequote: null      # bools can only be set to true

--- a/examples/gristle_freaker/example-03.yml
+++ b/examples/gristle_freaker/example-03.yml
@@ -6,9 +6,9 @@ columns: [1]
 verbosity: normal
 
 delimiter: null
-doublequote: null
 escapechar: null
-has_header: null
 quotechar: null
 quoting: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#has_header: null               # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_freaker/example-04.yml
+++ b/examples/gristle_freaker/example-04.yml
@@ -10,4 +10,4 @@ verbosity: normal
 
 escapechar: null
 quotechar: null
-skipinitialspace: null
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_freaker/example-05.yml
+++ b/examples/gristle_freaker/example-05.yml
@@ -9,5 +9,5 @@ has_header: true
 verbosity: normal
 
 quotechar: null
-doublequote: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_freaker/example-06.yml
+++ b/examples/gristle_freaker/example-06.yml
@@ -8,6 +8,6 @@ delimiter: ','
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_freaker/example-07.yml
+++ b/examples/gristle_freaker/example-07.yml
@@ -8,6 +8,6 @@ delimiter: ','
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_freaker/example-08.yml
+++ b/examples/gristle_freaker/example-08.yml
@@ -9,9 +9,9 @@ verbosity: normal
 
 # Not going to provide any dialect info - but will instead let the program auto-detect it:
 delimiter: null
-doublequote: null
 escapechar: null
-has_header: null
 quotechar: null
 quoting: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#has_header: null               # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_freaker/example-21.yml
+++ b/examples/gristle_freaker/example-21.yml
@@ -12,6 +12,6 @@ delimiter: '|'
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_freaker/example-22.yml
+++ b/examples/gristle_freaker/example-22.yml
@@ -9,6 +9,6 @@ delimiter: '|'
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_freaker/example-23.yml
+++ b/examples/gristle_freaker/example-23.yml
@@ -10,6 +10,6 @@ delimiter: '|'
 escapechar: \
 has_header: true
 
-doublequote: null
-quotechar: null
-skipinitialspace: null
+quotechar: null                 
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_freaker/example-24.yml
+++ b/examples/gristle_freaker/example-24.yml
@@ -11,6 +11,6 @@ delimiter: '|'
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_freaker/example-25.yml
+++ b/examples/gristle_freaker/example-25.yml
@@ -11,6 +11,6 @@ delimiter: '|'
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_profiler/example-01.yml
+++ b/examples/gristle_profiler/example-01.yml
@@ -1,13 +1,13 @@
 infiles: [example-01_dialect-qnone_input.csv]
 outfile: /tmp/example-01_actualout.csv
-output-format: parsable
+output_format: parsable
 verbosity: debug
 
 quoting: quote_none
 delimiter: ','
 escapechar: \
 
-doublequote: null
 has_header: true
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_profiler/example-02.yml
+++ b/examples/gristle_profiler/example-02.yml
@@ -1,12 +1,12 @@
 infiles: [example-02_dialect-qnone-skipinitialspace_input.csv]
 outfile: /tmp/example-02_actualout.csv
-output-format: parsable
+output_format: parsable
 verbosity: debug
 
 quoting: quote_none
 delimiter: ','
-doublequote: null
 escapechar: null
 has_header: true
 quotechar: null
+#doublequote: null              # will default to false
 skipinitialspace: true

--- a/examples/gristle_profiler/example-03.yml
+++ b/examples/gristle_profiler/example-03.yml
@@ -1,14 +1,14 @@
 # Ensure auto-detection works on a simple file
 infiles: [example-03_dialect-qnone-autodetect_input.csv]
 outfile: /tmp/example-03_actualout.csv
-output-format: parsable
+output_format: parsable
 
 verbosity: normal
 
 delimiter: null
-doublequote: null
 escapechar: null
-has_header: null
 quotechar: null
 quoting: null
-skipinitialspace: null
+#doublequote: null              # nulls can only be set to true
+#has_header: null               # nulls can only be set to true
+#skipinitialspace: null         # nulls can only be set to true

--- a/examples/gristle_profiler/example-04.yml
+++ b/examples/gristle_profiler/example-04.yml
@@ -1,6 +1,6 @@
 infiles: [example-04_dialect-qall-doublequote_input.csv]
 outfile: /tmp/example-04_actualout.csv
-output-format: parsable
+output_format: parsable
 verbosity: normal
 
 quoting: quote_all
@@ -10,4 +10,4 @@ has_header: true
 
 quotechar: null
 escapechar: null
-skipinitialspace: null
+#skipinitialspace: null         # nulls can only be set to true

--- a/examples/gristle_profiler/example-05.yml
+++ b/examples/gristle_profiler/example-05.yml
@@ -1,6 +1,6 @@
 infiles: [example-05_dialect-qall-escape_input.csv]
 outfile: /tmp/example-05_actualout.csv
-output-format: parsable
+output_format: parsable
 verbosity: normal
 
 quoting: quote_all
@@ -8,6 +8,6 @@ delimiter: ','
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_profiler/example-06.yml
+++ b/examples/gristle_profiler/example-06.yml
@@ -1,6 +1,6 @@
 infiles: [example-06_dialect-qmin_input.csv]
 outfile: /tmp/example-06_actualout.csv
-output-format: parsable
+output_format: parsable
 verbosity: normal
 
 quoting: quote_minimal
@@ -8,6 +8,6 @@ delimiter: ','
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_profiler/example-07.yml
+++ b/examples/gristle_profiler/example-07.yml
@@ -1,6 +1,6 @@
 infiles: [example-07_dialect-qnonnum_input.csv]
 outfile: /tmp/example-07_actualout.csv
-output-format: parsable
+output_format: parsable
 verbosity: normal
 
 quoting: quote_nonnumeric
@@ -8,6 +8,6 @@ delimiter: ','
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_profiler/example-08.yml
+++ b/examples/gristle_profiler/example-08.yml
@@ -1,6 +1,6 @@
 infiles: [example-08_hasheader_colnum_input.csv]
 outfile: /tmp/example-08_actualout.csv
-output-format: parsable
+output_format: parsable
 verbosity: debug
 column: 0
 
@@ -8,7 +8,7 @@ quoting: quote_none
 delimiter: ','
 escapechar: \
 
-doublequote: null
 has_header: true
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_profiler/example-09.yml
+++ b/examples/gristle_profiler/example-09.yml
@@ -1,6 +1,6 @@
 infiles: [example-08_hasheader_colnum_input.csv]
 outfile: /tmp/example-08_actualout.csv
-output-format: parsable
+output_format: parsable
 verbosity: debug
 column: num
 
@@ -8,7 +8,7 @@ quoting: quote_none
 delimiter: ','
 escapechar: \
 
-doublequote: null
 has_header: true
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_slicer/example-01.yml
+++ b/examples/gristle_slicer/example-01.yml
@@ -3,8 +3,8 @@ outfile: /tmp/example-01_dialect-qnone_actualout.csv
 
 quoting: quote_none
 delimiter: ','
-doublequote: null
 escapechar: \
 has_header: true
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_slicer/example-02.yml
+++ b/examples/gristle_slicer/example-02.yml
@@ -3,8 +3,8 @@ outfile: /tmp/example-02_actualout.csv
 
 quoting: quote_none
 delimiter: ','
-doublequote: null
 escapechar: null
 has_header: true
 quotechar: null
 skipinitialspace: true
+#doublequote: null              # bools can only be set to true

--- a/examples/gristle_slicer/example-03.yml
+++ b/examples/gristle_slicer/example-03.yml
@@ -4,8 +4,9 @@ outfile: /tmp/example-03_actualout.csv
 
 quotechar: null
 delimiter: null
-doublequote: null
 escapechar: null
-has_header: null
 quoting: null
-skipinitialspace: null
+
+#has_header: null               # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true
+#doublequote: null              # bools can only be set to true

--- a/examples/gristle_slicer/example-04.yml
+++ b/examples/gristle_slicer/example-04.yml
@@ -1,9 +1,10 @@
+infiles: [example-04_dialect-qall-doublequote_input.csv]
+outfile: /tmp/example-04_actualout.csv
+
 delimiter: ','
 doublequote: true
 escapechar: null
 has_header: true
-infiles: [example-04_dialect-qall-doublequote_input.csv]
-outfile: /tmp/example-04_actualout.csv
 quotechar: null
 quoting: quote_all
-skipinitialspace: null
+#skipinitialspace: null       # bools can only be set to true 

--- a/examples/gristle_slicer/example-05.yml
+++ b/examples/gristle_slicer/example-05.yml
@@ -7,5 +7,5 @@ escapechar: \
 has_header: true
 
 quotechar: null
-doublequote: null
-skipinitialspace: null
+#doublequote: null               # bools can only be set to true
+#skipinitialspace: null          # bools can only be set to true

--- a/examples/gristle_slicer/example-06.yml
+++ b/examples/gristle_slicer/example-06.yml
@@ -7,6 +7,6 @@ delimiter: ','
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null                      # bools can only be set to true
+#skipinitialspace: null                 # bools can only be set to true

--- a/examples/gristle_slicer/example-07.yml
+++ b/examples/gristle_slicer/example-07.yml
@@ -7,6 +7,6 @@ delimiter: ','
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null               # bools can only be set to true
+#skipinitialspace: null          # bools can only be set to true

--- a/examples/gristle_slicer/example-21.yml
+++ b/examples/gristle_slicer/example-21.yml
@@ -11,8 +11,8 @@ records: '2, 4'       # includes rows 2 and 4
 
 quoting: quote_none
 delimiter: '|'
-doublequote: null
 escapechar: \
 has_header: true
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_slicer/example-22.yml
+++ b/examples/gristle_slicer/example-22.yml
@@ -14,8 +14,8 @@ records: '2:5'       # includes rows 2, 3, and 4
 quoting: quote_none
 delimiter: '|'
 escapechar: \
-has_header: false
+has_no_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null               # bools can only be set to true
+#skipinitialspace: null          # bools can only be set to true

--- a/examples/gristle_slicer/example-23.yml
+++ b/examples/gristle_slicer/example-23.yml
@@ -14,8 +14,8 @@ exrecords: '2:5'       # excludes rows 2, 3, and 4
 quoting: quote_none
 delimiter: '|'
 escapechar: \
-has_header: false
+has_no_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_slicer/example-24.yml
+++ b/examples/gristle_slicer/example-24.yml
@@ -15,8 +15,8 @@ exrecords: '3:5'       # then excludes rows 2 and 4 in the middle
 quoting: quote_none
 delimiter: '|'
 escapechar: \
-has_header: false
+has_no_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_slicer/example-25.yml
+++ b/examples/gristle_slicer/example-25.yml
@@ -14,6 +14,6 @@ delimiter: '|'
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_sorter/example-01.yml
+++ b/examples/gristle_sorter/example-01.yml
@@ -1,13 +1,13 @@
 infiles: [example-01_dialect-qnone_input.csv]
 outfile: /tmp/example-01_dialect-qnone_actualout.csv
 keys: [1sf]
-dedupe: false
+#dedupe: true                   # will default to false
 verbosity: normal
 
 quoting: quote_none
 delimiter: ','
-doublequote: null
 escapechar: \
 has_header: true
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_sorter/example-02.yml
+++ b/examples/gristle_sorter/example-02.yml
@@ -1,13 +1,13 @@
 infiles: [example-02_dialect-qnone-skipinitialspace_input.csv]
 outfile: /tmp/example-02_actualout.csv
 keys: [1sf]
-dedupe: false
+#dedupe: true                   # will default to true
 verbosity: normal
 
 quoting: quote_none
 delimiter: ','
-doublequote: null
 escapechar: null
 has_header: true
 quotechar: null
 skipinitialspace: true
+#doublequote: null              # bools can only be set to true

--- a/examples/gristle_sorter/example-03.yml
+++ b/examples/gristle_sorter/example-03.yml
@@ -2,13 +2,13 @@
 infiles: [example-03_dialect-qnone-autodetect_input.csv]
 outfile: /tmp/example-03_actualout.csv
 keys: [1sf]
-dedupe: false
+#dedupe: true                   # will default to false
 verbosity: normal
 
 delimiter: null
-doublequote: null
 escapechar: null
-has_header: null
 quotechar: null
 quoting: null
-skipinitialspace: null
+#has_header: null               # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true
+#doublequote: null              # bools can only be set to true

--- a/examples/gristle_sorter/example-04.yml
+++ b/examples/gristle_sorter/example-04.yml
@@ -1,13 +1,14 @@
 infiles: [example-04_dialect-qall-doublequote_input.csv]
 outfile: /tmp/example-04-doublequote_actualout.csv
 keys: [1sf]
+#dedupe: true                   # will default to false
+
 verbosity: normal
 
 quoting: quote_all
-dedupe: false
 delimiter: ','
 doublequote: true
 escapechar: null
 has_header: true
 quotechar: null
-skipinitialspace: null
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_sorter/example-05.yml
+++ b/examples/gristle_sorter/example-05.yml
@@ -1,13 +1,13 @@
 infiles: [example-05_dialect-qall-escape_input.csv]
 outfile: /tmp/example-05-escape_actualout.csv
 keys: [1sf]
-dedupe: false
+#dedupe: true                   # will default to false
 verbosity: normal
 
 quoting: quote_all
 delimiter: ','
-doublequote: null
 escapechar: \
 has_header: true
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_sorter/example-06.yml
+++ b/examples/gristle_sorter/example-06.yml
@@ -1,7 +1,7 @@
 infiles: [example-06_dialect-qmin_input.csv]
 outfile: /tmp/example-06_actualout.csv
 keys: [1sf]
-dedupe: false
+#dedupe: true                   # will default to false
 verbosity: normal
 
 quoting: quote_minimal
@@ -9,6 +9,6 @@ delimiter: ','
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_sorter/example-07.yml
+++ b/examples/gristle_sorter/example-07.yml
@@ -1,7 +1,7 @@
 infiles: [example-07_dialect-qnonnum_input.csv]
 outfile: /tmp/example-07_actualout.csv
 keys: [1sf]
-dedupe: false
+#dedupe: true                   # will default to false
 verbosity: normal
 
 quoting: quote_nonnumeric
@@ -9,6 +9,6 @@ delimiter: ','
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_sorter/example-21.yml
+++ b/examples/gristle_sorter/example-21.yml
@@ -10,8 +10,8 @@ verbosity: debug
 
 quoting: quote_none
 delimiter: ','
-doublequote: null
 escapechar: \
 has_header: true
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_sorter/example-22.yml
+++ b/examples/gristle_sorter/example-22.yml
@@ -16,8 +16,8 @@ keys: [0sf, 1if, 2sr, 3fr]
 
 quoting: quote_none
 delimiter: ','
-doublequote: null
 escapechar: \
 has_header: true
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_sorter/example-23.yml
+++ b/examples/gristle_sorter/example-23.yml
@@ -16,8 +16,8 @@ keys: [alpha1sf, int~i~f, 2~s~r, 3fr]
 
 quoting: quote_none
 delimiter: ','
-doublequote: null
 escapechar: \
 has_header: true
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_validator/example-01.yml
+++ b/examples/gristle_validator/example-01.yml
@@ -5,8 +5,8 @@ verbosity: normal
 
 quoting: quote_none
 delimiter: ','
-doublequote: null
 escapechar: \
 has_header: true
 quotechar: null
-skipinitialspace: null
+#doublequote: null               # bools can only be set to true
+#skipinitialspace: null          # bools can only be set to true

--- a/examples/gristle_validator/example-02.yml
+++ b/examples/gristle_validator/example-02.yml
@@ -5,8 +5,8 @@ verbosity: normal
 
 quoting: quote_none
 delimiter: ','
-doublequote: null
 escapechar: null
 has_header: true
 quotechar: null
-skipinitialspace: true
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: true         # bools can only be set to true

--- a/examples/gristle_validator/example-03.yml
+++ b/examples/gristle_validator/example-03.yml
@@ -4,9 +4,9 @@ errfile: /tmp/example-03_dialect-qnone_actualout_err.csv
 verbosity: normal
 
 delimiter: null
-doublequote: null
 escapechar: null
-has_header: null
 quotechar: null
 quoting: null
-skipinitialspace: null
+#has_header: null               # bools can only be set to true
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_validator/example-04.yml
+++ b/examples/gristle_validator/example-04.yml
@@ -9,4 +9,4 @@ doublequote: true
 escapechar: null
 has_header: true
 quotechar: null
-skipinitialspace: null
+#skipinitialspace: null                 # bools can only be set to true

--- a/examples/gristle_validator/example-05.yml
+++ b/examples/gristle_validator/example-05.yml
@@ -5,8 +5,8 @@ verbosity: normal
 
 quoting: quote_all
 delimiter: ','
-doublequote: null
 escapechar: \
 has_header: true
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_validator/example-06.yml
+++ b/examples/gristle_validator/example-06.yml
@@ -8,6 +8,6 @@ delimiter: ','
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_validator/example-07.yml
+++ b/examples/gristle_validator/example-07.yml
@@ -8,6 +8,6 @@ delimiter: ','
 escapechar: \
 has_header: true
 
-doublequote: null
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_validator/example-21.yml
+++ b/examples/gristle_validator/example-21.yml
@@ -5,8 +5,8 @@ verbosity: normal
 
 quoting: quote_none
 delimiter: ','
-doublequote: null
 escapechar: \
 has_header: true
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_validator/example-22.yml
+++ b/examples/gristle_validator/example-22.yml
@@ -6,8 +6,8 @@ verbosity: normal
 
 quoting: quote_none
 delimiter: ','
-doublequote: null
 escapechar: \
 has_header: true
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_validator/example-23.yml
+++ b/examples/gristle_validator/example-23.yml
@@ -7,8 +7,8 @@ verbosity: normal
 
 quoting: quote_none
 delimiter: ','
-doublequote: null
 escapechar: \
 has_header: true
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/examples/gristle_validator/example-24.yml
+++ b/examples/gristle_validator/example-24.yml
@@ -9,8 +9,8 @@ err_out_fields: true
 
 quoting: quote_none
 delimiter: ','
-doublequote: null
 escapechar: \
 has_header: true
 quotechar: null
-skipinitialspace: null
+#doublequote: null              # bools can only be set to true
+#skipinitialspace: null         # bools can only be set to true

--- a/scripts/tests/test_gristle_differ_cmd.py
+++ b/scripts/tests/test_gristle_differ_cmd.py
@@ -47,7 +47,7 @@ class TestInvalidInput(object):
         self.file2 = generate_test_file(self.temp_dir, 'new_', '.csv', self.dialect, file2_recs)
         self.config = Config(self.temp_dir)
         self.config.add_property({'delimiter':'tab'})
-        self.config.add_property({'has_header':False})
+        self.config.add_property({'has_no_header':True})
         self.config.add_property({'quoting':'quote_none'})
         self.config.add_property({'col_names': ['col0', 'col1', 'col2']})
         self.config.add_property({'key_cols': ['0']})
@@ -82,7 +82,8 @@ class TestInvalidInput(object):
         cmd = ''' %s   \
                   --config-fn %s \
               ''' % (pjoin(script_dir, 'gristle_differ'), self.config.config_fqfn)
-        executor(cmd, expect_success=False)
+        output = executor(cmd, expect_success=False)
+        assert 'colname' in output
 
 
 class TestCommandLine(object):
@@ -205,7 +206,7 @@ class TestCommandLine(object):
         config = Config(self.temp_dir)
         config.add_property({'delimiter':'tab'})
         config.add_property({'quoting':'quote_none'})
-        config.add_property({'has_header':False})
+        config.add_property({'has_no_header':True})
         config.write_config()
 
         self.dialect.delimiter = '\t'
@@ -357,12 +358,13 @@ class TestCommandLine(object):
 
 def executor(cmd, expect_success=True):
     runner = envoy.run(cmd)
-    print(runner.std_out)
-    print(runner.std_err)
+    output = runner.std_out + runner.std_err
+    print(output)
     if expect_success:
         assert runner.status_code == 0
     else:
         assert runner.status_code != 0
+    return output
 
 
 

--- a/scripts/tests/test_gristle_differ_cmd_slow.py
+++ b/scripts/tests/test_gristle_differ_cmd_slow.py
@@ -61,7 +61,7 @@ class TestBigFile(object):
         file2 = pjoin(self.temp_dir, 'new.csv')
         config = Config(self.temp_dir)
         config.add_property({'delimiter':','})
-        config.add_property({'has_header':False})
+        config.add_property({'has_no_header':True})
         config.add_property({'quoting':'quote_none'})
         config.add_property({'col_names': sorted(FIELDS, key=FIELDS.get)})
         config.add_property({'key_cols':  ['pkid']})

--- a/scripts/tests/test_gristle_differ_example_cmds.py
+++ b/scripts/tests/test_gristle_differ_example_cmds.py
@@ -100,13 +100,13 @@ class TestExamples(test_tools.TestExamples):
         self.expected_files = glob.glob(pjoin(self.example_dir, f'{example_number}_output_files/*csv*'))
 
         self.load_config(example_number)
-        self.actual_dir = self.config['out-dir']
+        self.actual_dir = self.config['out_dir']
         self.create_output_dir(self.actual_dir)
         self.make_command(example_number)
         print('\n**** Execution: ****')
         test_tools.executor(self.cmd, expect_success=True)
 
-        self.actual_files = glob.glob(pjoin(self.config['out-dir'], f'{example_number}_*csv*'))
+        self.actual_files = glob.glob(pjoin(self.config['out_dir'], f'{example_number}_*csv*'))
         self.print_files()
 
         print('\n**** os diff of files: ****')


### PR DESCRIPTION
The problem is that file configs and envvars don't handle bools the same
way that the cli does: rather than always apply the const value, the
user can set them to None, False, '', etc.

This change ensures that the only value accepted from envvars or config
files for booleans are true, True, t, or 1.  Anything else will result
in the program aborting. And then the const value is applied, not the
given value.