### PR TITLE
Enforce minimum python version of 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-# V0.2.2 - 2021-05
+# V0.2.2 - 2021-07
    * Improvement: the field-names from headers can now be used instead of column offsets
      for gristle_sorter, gristle_freaker, gristle_profiler, and gristle_slicer.
    * Improvement: The use of the header now follows four simple rules:
@@ -8,6 +8,12 @@
        - It will be passed through when it makes sense - like with gristle_sorter.
        - It will be used to translate field names to offsets for configuration.
        - But will otherwise be ignored.
+   * Improvement: is now enforcing the minimum version of 3.8.  It was previously almost
+     completely working on 3.7 but would occasionally crash on a 3.8 feature.  
+   * BREAKING CHANGE: Removed gristle_processor.
+   * BREAKING CHANGE: envvar and config file boolean args with values other than True, true,
+     t, or 1 will be rejected.  This is because they can be very ambiguous and confusing,
+     in particular with with a pair of args like has-header and has-no-header.
    * Bug Fix: gristle_freaker was failing with 0-length files when using col-type=each
    * Bug Fix: gristle_sorter was failing with some multi-directional sorts
   

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-V0.2.2 - 2021-05
+V0.2.2 - 2021-07
 ================
 
 -  Improvement: the field-names from headers can now be used instead of
@@ -14,6 +14,14 @@ V0.2.2 - 2021-05
       configuration.
    -  But will otherwise be ignored.
 
+-  Improvement: is now enforcing the minimum version of 3.8. It was
+   previously almost completely working on 3.7 but would occasionally
+   crash on a 3.8 feature.
+-  BREAKING CHANGE: Removed gristle_processor.
+-  BREAKING CHANGE: envvar and config file boolean args with values
+   other than True, true, t, or 1 will be rejected. This is because they
+   can be very ambiguous and confusing, in particular with with a pair
+   of args like has-header and has-no-header.
 -  Bug Fix: gristle_freaker was failing with 0-length files when using
    col-type=each
 -  Bug Fix: gristle_sorter was failing with some multi-directional sorts

--- a/datagristle/common.py
+++ b/datagristle/common.py
@@ -241,3 +241,11 @@ def get_col_names_from_header(file1_fqfn: str,
         return col_names
     except StopIteration:
         return None
+
+
+def validate_python_version():
+    if sys.version_info.major != 3 or sys.version_info.minor < 8:
+        abort('Error: invalid version of python',
+              'Minimum version is 3.8 but this is being run on '
+              f'{sys.version_info.major}.{sys.version_info.minor}')
+


### PR DESCRIPTION
Instead of letting people use it on 3.7 and have it crash occasionally,
it will now check before it runs anything significant and abort if not
on 3.8+