### PR TITLE
slicer - add file_index

### DIFF
--- a/scripts/gristle_slicer
+++ b/scripts/gristle_slicer
@@ -161,6 +161,7 @@ from typing import List, Tuple, Dict, Any, Optional, IO, Hashable
 import datagristle.common as comm
 import datagristle.configulator as conf
 from datagristle import helpdoc
+import datagristle.metadata as metadata
 import datagristle.slice_processor as processor
 
 #Ignore SIG_PIPE and don't throw exceptions on it... (http://docs.python.org/library/signal.html)
@@ -185,7 +186,9 @@ def main() -> int:
     except EOFError:
         return errno.ENODATA
 
-    slice_runner = processor.SliceRunner(config_manager)
+    md = metadata.GristleMetaData()
+
+    slice_runner = processor.SliceRunner(config_manager, md)
     slice_runner.setup_stage1()
     slice_runner.setup_stage2()
     slice_runner.process_data()


### PR DESCRIPTION
This adds the file_index metadata table, featuring:
   * new md table
   * keeps track of slicer input file record counts
   * slicers uses this to avoid unnecessary record-counting